### PR TITLE
Rename --relax to --allow-growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Run `loq baseline` periodically to ratchet down. It automatically:
 - **Updates** rules when files shrink (tightens the limit)
 - **Removes** rules when files drop below the threshold
 
-Files that grow beyond their baseline are left unchanged by default—increasing limits defeats the purpose of the fence. If you must, use `--relax`:
+Files that grow beyond their baseline are left unchanged by default—increasing limits defeats the purpose of the fence. If you must, use `--allow-growth`:
 
 ```bash
-loq baseline --relax   # Also update limits for files that grew
+loq baseline --allow-growth   # Also update limits for files that grew
 ```
 
 Use `--threshold` to override the default limit:

--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -70,7 +70,7 @@ fn run_baseline_inner(args: &BaselineArgs) -> Result<BaselineStats> {
     let existing_rules = collect_exact_path_rules(&doc);
 
     // Step 5: Compute changes
-    let stats = apply_baseline_changes(&mut doc, &violations, &existing_rules, args.relax);
+    let stats = apply_baseline_changes(&mut doc, &violations, &existing_rules, args.allow_growth);
 
     // Step 6: Write config back
     std::fs::write(&config_path, doc.to_string())
@@ -209,7 +209,7 @@ fn apply_baseline_changes(
     doc: &mut DocumentMut,
     violations: &HashMap<String, usize>,
     existing_rules: &HashMap<String, (usize, usize)>,
-    relax: bool,
+    allow_growth: bool,
 ) -> BaselineStats {
     let mut stats = BaselineStats {
         added: 0,
@@ -228,12 +228,12 @@ fn apply_baseline_changes(
                 // File shrunk - always tighten the limit
                 update_rule_max_lines(doc, *idx, actual);
                 stats.updated += 1;
-            } else if actual > *current_limit && relax {
-                // File grew - only update if --relax is set
+            } else if actual > *current_limit && allow_growth {
+                // File grew - only update if --allow-growth is set
                 update_rule_max_lines(doc, *idx, actual);
                 stats.updated += 1;
             }
-            // If actual == current_limit, or grew without --relax, leave unchanged
+            // If actual == current_limit, or grew without --allow-growth, leave unchanged
         } else {
             // File is now compliant (under threshold) - remove the rule
             indices_to_remove.push(*idx);

--- a/crates/loq_cli/src/cli.rs
+++ b/crates/loq_cli/src/cli.rs
@@ -52,6 +52,6 @@ pub struct BaselineArgs {
     pub threshold: Option<usize>,
 
     /// Allow increasing limits for files that grew beyond their baseline.
-    #[arg(long = "relax")]
-    pub relax: bool,
+    #[arg(long = "allow-growth")]
+    pub allow_growth: bool,
 }

--- a/crates/loq_cli/tests/baseline_allow_growth.rs
+++ b/crates/loq_cli/tests/baseline_allow_growth.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the --relax flag.
+//! Integration tests for the --allow-growth flag.
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
@@ -18,8 +18,8 @@ fn repeat_lines(count: usize) -> String {
 
 #[test]
 fn updates_grown_files() {
-    // Without --relax, grown files are left unchanged
-    // With --relax, grown files get updated limits
+    // Without --allow-growth, grown files are left unchanged
+    // With --allow-growth, grown files get updated limits
     let temp = TempDir::new().unwrap();
     let config = r#"default_max_lines = 500
 
@@ -33,7 +33,7 @@ max_lines = 600
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline", "--relax"])
+        .args(["baseline", "--allow-growth"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Updated 1 rule"));
@@ -45,7 +45,7 @@ max_lines = 600
 
 #[test]
 fn handles_mixed_changes() {
-    // Scenario with --relax:
+    // Scenario with --allow-growth:
     // - file_a: shrinks (always updated)
     // - file_b: grows (updated because of flag)
     // - file_c: unchanged (no update needed)
@@ -82,7 +82,7 @@ max_lines = 550
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline", "--relax"])
+        .args(["baseline", "--allow-growth"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Updated 2 rules"))
@@ -121,7 +121,7 @@ max_lines = 600
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline"]) // No --relax
+        .args(["baseline"]) // No --allow-growth
         .assert()
         .success()
         .stdout(predicate::str::contains("No changes needed"));
@@ -134,7 +134,7 @@ max_lines = 600
 
 #[test]
 fn combined_with_threshold() {
-    // --relax works with --threshold
+    // --allow-growth works with --threshold
     let temp = TempDir::new().unwrap();
     let config = r#"default_max_lines = 500
 
@@ -147,10 +147,10 @@ max_lines = 400
     write_file(&temp, "file.txt", &repeat_lines(450));
 
     // With --threshold 300, file is a violation (450 > 300)
-    // With --relax, the limit should update from 400 to 450
+    // With --allow-growth, the limit should update from 400 to 450
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline", "--threshold", "300", "--relax"])
+        .args(["baseline", "--threshold", "300", "--allow-growth"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Updated 1 rule"));
@@ -162,7 +162,7 @@ max_lines = 400
 
 #[test]
 fn only_affects_exact_path_rules() {
-    // Glob rules should never be updated, even with --relax
+    // Glob rules should never be updated, even with --allow-growth
     let temp = TempDir::new().unwrap();
     let config = r#"default_max_lines = 500
 
@@ -182,7 +182,7 @@ max_lines = 600
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline", "--relax"])
+        .args(["baseline", "--allow-growth"])
         .assert()
         .success();
 
@@ -213,7 +213,7 @@ max_lines = 800
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["baseline", "--relax"])
+        .args(["baseline", "--allow-growth"])
         .assert()
         .success();
 


### PR DESCRIPTION
## Summary

- `--allow-growth` is self-documenting—users understand it without checking docs
- "Relax" was ambiguous: relax enforcement? relax limits upward?

🤖 Generated with [Claude Code](https://claude.com/claude-code)