### PR TITLE
Add CI benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,84 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release -p loq
+
+      - name: Install hyperfine
+        run: |
+          wget https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
+          sudo dpkg -i hyperfine_1.18.0_amd64.deb
+
+      - name: Clone benchmark repos
+        run: |
+          mkdir -p bench-repos
+          git clone --depth 1 https://github.com/python/cpython.git bench-repos/cpython
+          git clone --depth 1 https://github.com/apache/airflow.git bench-repos/airflow
+          git clone --depth 1 https://github.com/PrefectHQ/prefect.git bench-repos/prefect
+          git clone --depth 1 https://github.com/astral-sh/ruff.git bench-repos/ruff
+
+      - name: Run benchmarks
+        run: |
+          hyperfine \
+            --warmup 3 \
+            --runs 10 \
+            --ignore-failure \
+            --export-json bench-results.json \
+            -n cpython './target/release/loq check bench-repos/cpython --silent --no-cache' \
+            -n airflow './target/release/loq check bench-repos/airflow --silent --no-cache' \
+            -n prefect './target/release/loq check bench-repos/prefect --silent --no-cache' \
+            -n ruff './target/release/loq check bench-repos/ruff --silent --no-cache'
+
+      - name: Convert results for benchmark action
+        run: |
+          python3 << 'EOF'
+          import json
+
+          with open("bench-results.json") as f:
+              data = json.load(f)
+
+          results = []
+          for r in data["results"]:
+              results.append({
+                  "name": r["command"],
+                  "unit": "seconds",
+                  "value": r["mean"],
+                  "range": f"± {r['stddev']:.4f}"
+              })
+
+          with open("benchmark-results.json", "w") as f:
+              json.dump(results, f, indent=2)
+          EOF
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -12,12 +17,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
 
       - name: Format
         run: cargo fmt --all -- --check
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Loq (self-check)
+        run: cargo run -p loq -- check .
 
   test:
     runs-on: ${{ matrix.os }}
@@ -27,21 +36,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-
-      - name: Loq (self-check)
-        run: cargo run -p loq -- check .
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         run: cargo test --all
-
-      - name: Doc tests
-        run: cargo test --doc
 
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Coverage
@@ -59,7 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-audit
       - uses: taiki-e/install-action@cargo-deny
 

--- a/justfile
+++ b/justfile
@@ -39,4 +39,4 @@ bench repo:
     trap "rm -rf $TMPDIR" EXIT
     git clone --depth 1 "{{ repo }}" "$TMPDIR/repo"
     hyperfine --warmup 3 --runs 10 --ignore-failure \
-        "./target/release/loq check $TMPDIR/repo --silent"
+        "./target/release/loq check $TMPDIR/repo --silent --no-cache"


### PR DESCRIPTION
## Summary
- Adds benchmark workflow against cpython, airflow, prefect, ruff with PR comments via github-action-benchmark
- Adds `--no-cache` flag to `just bench`
- CI cleanup: rust caching, concurrency groups, removes redundant steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)