### PR TITLE
Centralize cached file inspection

### DIFF
--- a/crates/loq_fs/src/inspection.rs
+++ b/crates/loq_fs/src/inspection.rs
@@ -1,0 +1,159 @@
+//! Cached file inspection.
+//!
+//! Owns file metadata lookup, cache policy, line inspection, and conversion to
+//! check outcomes.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use loq_core::{MatchBy, OutcomeKind};
+
+use crate::cache::{Cache, CachedResult};
+use crate::count::{self, FileInspection};
+
+/// Inspects files with a shared cache.
+pub(crate) struct Inspector {
+    cache: Mutex<Cache>,
+}
+
+impl Inspector {
+    /// Creates an inspector backed by `cache`.
+    pub(crate) const fn new(cache: Cache) -> Self {
+        Self {
+            cache: Mutex::new(cache),
+        }
+    }
+
+    /// Inspects a file and returns its check outcome for the given limit.
+    pub(crate) fn inspect(
+        &self,
+        path: &Path,
+        cache_key: &str,
+        limit: usize,
+        matched_by: MatchBy,
+    ) -> OutcomeKind {
+        let mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+
+        if let Some(outcome) = self.cached_outcome(cache_key, mtime, limit, &matched_by) {
+            return outcome;
+        }
+
+        match count::inspect_file(path) {
+            Ok(FileInspection::Binary) => {
+                self.cache_result(cache_key, mtime, CachedResult::Binary);
+                OutcomeKind::Binary
+            }
+            Ok(FileInspection::Text { lines }) => {
+                self.cache_result(cache_key, mtime, CachedResult::Text(lines));
+                outcome_for_lines(lines, limit, matched_by)
+            }
+            Err(count::CountError::Missing) => OutcomeKind::Missing,
+            Err(count::CountError::Unreadable(error)) => OutcomeKind::Unreadable {
+                error: error.to_string(),
+            },
+        }
+    }
+
+    /// Consumes the inspector and returns the inner cache when no worker still holds it.
+    pub(crate) fn into_cache(self) -> Option<Cache> {
+        self.cache.into_inner().ok()
+    }
+
+    fn cached_outcome(
+        &self,
+        cache_key: &str,
+        mtime: Option<std::time::SystemTime>,
+        limit: usize,
+        matched_by: &MatchBy,
+    ) -> Option<OutcomeKind> {
+        let mt = mtime?;
+        let cache = self.cache.lock().ok()?;
+        let result = cache.get(cache_key, mt)?;
+        Some(cached_result_to_outcome(result, limit, matched_by.clone()))
+    }
+
+    fn cache_result(
+        &self,
+        cache_key: &str,
+        mtime: Option<std::time::SystemTime>,
+        result: CachedResult,
+    ) {
+        let Some(mt) = mtime else {
+            return;
+        };
+        let Ok(mut cache) = self.cache.lock() else {
+            return;
+        };
+        cache.insert(cache_key.to_string(), mt, result);
+    }
+}
+
+fn cached_result_to_outcome(
+    result: CachedResult,
+    limit: usize,
+    matched_by: MatchBy,
+) -> OutcomeKind {
+    match result {
+        CachedResult::Text(lines) => outcome_for_lines(lines, limit, matched_by),
+        CachedResult::Binary => OutcomeKind::Binary,
+    }
+}
+
+const fn outcome_for_lines(lines: usize, limit: usize, matched_by: MatchBy) -> OutcomeKind {
+    if lines > limit {
+        OutcomeKind::Violation {
+            limit,
+            actual: lines,
+            matched_by,
+        }
+    } else {
+        OutcomeKind::Pass {
+            limit,
+            actual: lines,
+            matched_by,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn text_file_outcome_uses_limit() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "a\nb\n").unwrap();
+        let inspector = Inspector::new(Cache::empty());
+
+        let outcome = inspector.inspect(file.path(), "a.rs", 1, MatchBy::Default);
+
+        match outcome {
+            OutcomeKind::Violation { actual, limit, .. } => {
+                assert_eq!(actual, 2);
+                assert_eq!(limit, 1);
+            }
+            other => panic!("expected violation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn binary_file_outcome_is_cached() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), b"\0binary").unwrap();
+        let inspector = Inspector::new(Cache::empty());
+
+        let outcome = inspector.inspect(file.path(), "bin.dat", 1, MatchBy::Default);
+
+        assert!(matches!(outcome, OutcomeKind::Binary));
+    }
+
+    #[test]
+    fn missing_file_is_not_cacheable() {
+        let inspector = Inspector::new(Cache::empty());
+
+        let outcome = inspector.inspect(Path::new("missing.rs"), "missing.rs", 1, MatchBy::Default);
+
+        assert!(matches!(outcome, OutcomeKind::Missing));
+    }
+}

--- a/crates/loq_fs/src/inspection.rs
+++ b/crates/loq_fs/src/inspection.rs
@@ -118,6 +118,8 @@ const fn outcome_for_lines(lines: usize, limit: usize, matched_by: MatchBy) -> O
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::AssertUnwindSafe;
+    use std::time::SystemTime;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -128,13 +130,14 @@ mod tests {
 
         let outcome = inspector.inspect(file.path(), "a.rs", 1, MatchBy::Default);
 
-        match outcome {
-            OutcomeKind::Violation { actual, limit, .. } => {
-                assert_eq!(actual, 2);
-                assert_eq!(limit, 1);
+        assert!(matches!(
+            outcome,
+            OutcomeKind::Violation {
+                actual: 2,
+                limit: 1,
+                ..
             }
-            other => panic!("expected violation, got {other:?}"),
-        }
+        ));
     }
 
     #[test]
@@ -155,5 +158,28 @@ mod tests {
         let outcome = inspector.inspect(Path::new("missing.rs"), "missing.rs", 1, MatchBy::Default);
 
         assert!(matches!(outcome, OutcomeKind::Missing));
+    }
+
+    #[test]
+    fn cache_result_ignores_missing_mtime() {
+        let inspector = Inspector::new(Cache::empty());
+
+        inspector.cache_result("a.rs", None, CachedResult::Text(1));
+
+        let cache = inspector.into_cache().unwrap();
+        assert!(cache.get("a.rs", SystemTime::UNIX_EPOCH).is_none());
+    }
+
+    #[test]
+    fn cache_result_ignores_poisoned_cache_lock() {
+        let inspector = Inspector::new(Cache::empty());
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let _guard = inspector.cache.lock().unwrap();
+            panic!("poison cache");
+        }));
+
+        assert!(result.is_err());
+        inspector.cache_result("a.rs", Some(SystemTime::UNIX_EPOCH), CachedResult::Text(1));
+        assert!(inspector.into_cache().is_none());
     }
 }

--- a/crates/loq_fs/src/lib.rs
+++ b/crates/loq_fs/src/lib.rs
@@ -9,6 +9,7 @@
 mod cache;
 pub mod count;
 pub mod discover;
+mod inspection;
 pub mod path_identity;
 pub mod stdin;
 pub mod walk;
@@ -16,12 +17,13 @@ pub mod walk;
 pub use path_identity::PathIdentity;
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 use loq_core::config::{compile_config, CompiledConfig, ConfigOrigin, LoqConfig};
 use loq_core::decide::{decide, Decision};
 use loq_core::report::{FileOutcome, OutcomeKind};
 use rayon::prelude::*;
+
+use inspection::Inspector;
 use thiserror::Error;
 
 /// Filesystem operation errors.
@@ -112,7 +114,7 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
     } else {
         cache::Cache::empty()
     };
-    let file_cache = Mutex::new(file_cache);
+    let inspector = Inspector::new(file_cache);
 
     // Step 3: Canonicalize cwd once (instead of per-file)
     let cwd_abs = options
@@ -134,11 +136,11 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
     file_list.dedup();
 
     // Step 5: Check all files in parallel
-    let outcomes = check_group(&file_list, &compiled, &cwd_abs, &file_cache);
+    let outcomes = check_group(&file_list, &compiled, &cwd_abs, &inspector);
 
     // Step 6: Save cache (if enabled) - cache lives at config root
     if options.use_cache {
-        if let Ok(cache) = file_cache.into_inner() {
+        if let Some(cache) = inspector.into_cache() {
             cache.save(&compiled.root_dir);
         }
     }
@@ -154,11 +156,11 @@ fn check_group(
     paths: &[PathBuf],
     compiled: &CompiledConfig,
     cwd_abs: &Path,
-    file_cache: &Mutex<cache::Cache>,
+    inspector: &Inspector,
 ) -> Vec<FileOutcome> {
     paths
         .par_iter()
-        .map(|path| check_file(path, compiled, cwd_abs, file_cache))
+        .map(|path| check_file(path, compiled, cwd_abs, inspector))
         .collect()
 }
 
@@ -166,7 +168,7 @@ fn check_file(
     path: &Path,
     compiled: &CompiledConfig,
     cwd_abs: &Path,
-    file_cache: &Mutex<cache::Cache>,
+    inspector: &Inspector,
 ) -> FileOutcome {
     let identity = PathIdentity::new(path, cwd_abs, &compiled.root_dir);
     let config_source = compiled.origin.clone();
@@ -182,110 +184,11 @@ fn check_file(
     let kind = match decide(compiled, &identity.match_key) {
         Decision::SkipNoLimit => OutcomeKind::NoLimit,
         Decision::Check { limit, matched_by } => {
-            check_file_lines(path, &identity.cache_key, limit, matched_by, file_cache)
+            inspector.inspect(path, &identity.cache_key, limit, matched_by)
         }
     };
 
     make_outcome(kind)
-}
-
-fn check_file_lines(
-    path: &Path,
-    cache_key: &str,
-    limit: usize,
-    matched_by: loq_core::MatchBy,
-    file_cache: &Mutex<cache::Cache>,
-) -> OutcomeKind {
-    // Get file mtime for cache lookup
-    let mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok();
-
-    // Try cache first (using relative path as key for consistency across directories)
-    if let Some(outcome) = try_cached_outcome(cache_key, mtime, file_cache, limit, &matched_by) {
-        return outcome;
-    }
-
-    // Cache miss - read file
-    match count::inspect_file(path) {
-        Ok(count::FileInspection::Binary) => {
-            cache_result(file_cache, cache_key, mtime, cache::CachedResult::Binary);
-            OutcomeKind::Binary
-        }
-        Ok(count::FileInspection::Text { lines }) => {
-            cache_result(
-                file_cache,
-                cache_key,
-                mtime,
-                cache::CachedResult::Text(lines),
-            );
-            outcome_for_lines(lines, limit, matched_by)
-        }
-        // Missing/Unreadable can't be cached (no mtime available)
-        Err(count::CountError::Missing) => OutcomeKind::Missing,
-        Err(count::CountError::Unreadable(error)) => OutcomeKind::Unreadable {
-            error: error.to_string(),
-        },
-    }
-}
-
-fn try_cached_outcome(
-    cache_key: &str,
-    mtime: Option<std::time::SystemTime>,
-    file_cache: &Mutex<cache::Cache>,
-    limit: usize,
-    matched_by: &loq_core::MatchBy,
-) -> Option<OutcomeKind> {
-    if let Some(mt) = mtime {
-        if let Ok(cache) = file_cache.lock() {
-            if let Some(result) = cache.get(cache_key, mt) {
-                return Some(cached_result_to_outcome(result, limit, matched_by.clone()));
-            }
-        }
-    }
-    None
-}
-
-fn cache_result(
-    file_cache: &Mutex<cache::Cache>,
-    cache_key: &str,
-    mtime: Option<std::time::SystemTime>,
-    result: cache::CachedResult,
-) {
-    if let Some(mt) = mtime {
-        if let Ok(mut cache) = file_cache.lock() {
-            cache.insert(cache_key.to_string(), mt, result);
-        }
-    }
-}
-
-fn cached_result_to_outcome(
-    result: cache::CachedResult,
-    limit: usize,
-    matched_by: loq_core::MatchBy,
-) -> OutcomeKind {
-    match result {
-        cache::CachedResult::Text(lines) => outcome_for_lines(lines, limit, matched_by),
-        cache::CachedResult::Binary => OutcomeKind::Binary,
-    }
-}
-
-const fn outcome_for_lines(
-    lines: usize,
-    limit: usize,
-    matched_by: loq_core::MatchBy,
-) -> OutcomeKind {
-    if lines > limit {
-        OutcomeKind::Violation {
-            limit,
-            actual: lines,
-            matched_by,
-        }
-    } else {
-        OutcomeKind::Pass {
-            limit,
-            actual: lines,
-            matched_by,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/loq_fs/src/tests.rs
+++ b/crates/loq_fs/src/tests.rs
@@ -89,14 +89,14 @@ fn binary_and_unreadable_are_reported() {
         None,
     )
     .unwrap();
-    let file_cache = Mutex::new(cache::Cache::empty());
+    let inspector = inspection::Inspector::new(cache::Cache::empty());
 
     let binary = temp.path().join("binary.txt");
     std::fs::write(&binary, b"\0binary").unwrap();
-    let binary_outcome = check_file(&binary, &compiled, temp.path(), &file_cache);
+    let binary_outcome = check_file(&binary, &compiled, temp.path(), &inspector);
     assert!(matches!(binary_outcome.kind, OutcomeKind::Binary));
 
-    let dir_outcome = check_file(temp.path(), &compiled, temp.path(), &file_cache);
+    let dir_outcome = check_file(temp.path(), &compiled, temp.path(), &inspector);
     assert!(matches!(dir_outcome.kind, OutcomeKind::Unreadable { .. }));
 }
 


### PR DESCRIPTION
File checking was doing cache lookup, metadata handling, file inspection, and outcome conversion inline in the check orchestration module. This adds an `Inspector` module that owns cached file inspection behind a small interface.

- Cache hit/miss handling, mtime lookup, binary/text inspection, and missing/unreadable behavior now live together.
- `loq_fs::run_check` keeps orchestration focused on config loading, walking, and reporting outcomes.
- Added focused tests for cached inspection outcomes while preserving existing check behavior.

Tests: `uvx prek run -a`.