### PR TITLE
[codex] improve CLI warning output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An electric fence for LLMs (and humans too). Written in Rust,
 
 ## Why loq?
 - 🔒 Hard limits to prevent oversized files and context rot
-- 📏 One metric: line counts (`wc -l` style)
+- 📏 Line counts first, with optional approximate token budgets for prompts and agent-facing files
 - 🧩 Works everywhere - no language-specific setup
 - 🤖 Designed specifically with coding agents in mind
 - 🦀 Lightning fast Rust core

--- a/crates/loq_cli/src/check.rs
+++ b/crates/loq_cli/src/check.rs
@@ -3,7 +3,7 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use loq_core::report::{build_report, FindingKind, Report};
+use loq_core::report::{build_report, Finding, FindingKind, Report, SkipReason};
 use loq_fs::{CheckOptions, CheckOutput, FsError};
 use termcolor::{Color, WriteColor};
 
@@ -105,7 +105,7 @@ fn write_text_output<W: WriteColor>(
 ) {
     let verbose = mode == OutputMode::Verbose;
     for finding in &report.findings {
-        if !verbose && matches!(finding.kind, FindingKind::SkipWarning { .. }) {
+        if !verbose && should_hide_finding(finding) {
             continue;
         }
         let _ = write_finding(stdout, finding, verbose);
@@ -119,6 +119,15 @@ fn write_text_output<W: WriteColor>(
     if !walk_errors.is_empty() {
         let _ = write_walk_errors(stdout, walk_errors, verbose);
     }
+}
+
+const fn should_hide_finding(finding: &Finding) -> bool {
+    matches!(
+        finding.kind,
+        FindingKind::SkipWarning {
+            reason: SkipReason::Binary | SkipReason::Unreadable(_)
+        }
+    )
 }
 
 #[cfg(test)]

--- a/crates/loq_cli/src/check/tests.rs
+++ b/crates/loq_cli/src/check/tests.rs
@@ -14,20 +14,29 @@ fn handle_fs_error_returns_error_status() {
 }
 
 #[test]
-fn handle_check_output_default_mode_skips_skip_warnings() {
+fn handle_check_output_default_mode_shows_missing_but_skips_other_warnings() {
     use loq_core::report::{FileOutcome, OutcomeKind};
     use loq_core::ConfigOrigin;
     use termcolor::NoColor;
 
     let mut stdout = NoColor::new(Vec::new());
     let output = loq_fs::CheckOutput {
-        outcomes: vec![FileOutcome {
-            path: "missing.txt".into(),
-            display_path: "missing.txt".into(),
-            match_key: "missing.txt".into(),
-            config_source: ConfigOrigin::BuiltIn,
-            kind: OutcomeKind::Missing,
-        }],
+        outcomes: vec![
+            FileOutcome {
+                path: "missing.txt".into(),
+                display_path: "missing.txt".into(),
+                match_key: "missing.txt".into(),
+                config_source: ConfigOrigin::BuiltIn,
+                kind: OutcomeKind::Missing,
+            },
+            FileOutcome {
+                path: "skipped.bin".into(),
+                display_path: "skipped.bin".into(),
+                match_key: "skipped.bin".into(),
+                config_source: ConfigOrigin::BuiltIn,
+                kind: OutcomeKind::Binary,
+            },
+        ],
         walk_errors: vec![],
         fix_guidance: None,
     };
@@ -36,7 +45,9 @@ fn handle_check_output_default_mode_skips_skip_warnings() {
     assert_eq!(status, ExitStatus::Success);
 
     let output_str = String::from_utf8(stdout.into_inner()).unwrap();
-    assert!(!output_str.contains("missing.txt") || output_str.contains("passed"));
+    assert!(output_str.contains("missing.txt"));
+    assert!(output_str.contains("file not found"));
+    assert!(!output_str.contains("skipped.bin"));
 }
 
 #[test]

--- a/crates/loq_cli/src/output/mod.rs
+++ b/crates/loq_cli/src/output/mod.rs
@@ -298,7 +298,8 @@ pub fn write_summary<W: WriteColor>(writer: &mut W, summary: &Summary) -> io::Re
         writer.set_color(&fg(Color::Green))?;
         write!(writer, "✔")?;
         writer.reset()?;
-        writeln!(writer, " {} files ok", format_number(summary.passed))?;
+        let word = if summary.passed == 1 { "file" } else { "files" };
+        writeln!(writer, " {} {word} ok", format_number(summary.passed))?;
     }
     writer.reset()
 }

--- a/crates/loq_cli/src/output/tests.rs
+++ b/crates/loq_cli/src/output/tests.rs
@@ -254,6 +254,19 @@ fn write_summary_all_passed() {
 }
 
 #[test]
+fn write_summary_one_file_passed() {
+    let summary = Summary {
+        total: 1,
+        skipped: 0,
+        passed: 1,
+        errors: 0,
+    };
+    let out = output_string(|w| write_summary(w, &summary));
+    assert!(out.contains("1 file ok"));
+    assert!(!out.contains("1 files ok"));
+}
+
+#[test]
 fn write_summary_single_violation() {
     let summary = Summary {
         total: 1,

--- a/crates/loq_cli/tests/cli.rs
+++ b/crates/loq_cli/tests/cli.rs
@@ -19,7 +19,7 @@ fn default_check_success() {
         .current_dir(temp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("files ok"));
+        .stdout(predicate::str::contains("1 file ok"));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn check_explicit_files() {
         .args(["check", "a.txt"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("files ok"));
+        .stdout(predicate::str::contains("1 file ok"));
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn missing_file_warns() {
 
     cargo_bin_cmd!("loq")
         .current_dir(temp.path())
-        .args(["--verbose", "check", "missing.txt"])
+        .args(["check", "missing.txt"])
         .assert()
         .success()
         .stdout(predicate::str::contains("⚠"))

--- a/crates/loq_cli/tests/snapshots/snapshots__baselined_file_passes.snap
+++ b/crates/loq_cli/tests/snapshots/snapshots__baselined_file_passes.snap
@@ -2,4 +2,4 @@
 source: crates/loq_cli/tests/snapshots.rs
 expression: stdout
 ---
-✔ 1 files ok
+✔ 1 file ok

--- a/crates/loq_cli/tests/snapshots/snapshots__binary_file_skipped.snap
+++ b/crates/loq_cli/tests/snapshots/snapshots__binary_file_skipped.snap
@@ -2,4 +2,4 @@
 source: crates/loq_cli/tests/snapshots.rs
 expression: stdout
 ---
-✔ 1 files ok
+✔ 1 file ok

--- a/crates/loq_cli/tests/snapshots/snapshots__missing_file_stdout.snap
+++ b/crates/loq_cli/tests/snapshots/snapshots__missing_file_stdout.snap
@@ -2,4 +2,5 @@
 source: crates/loq_cli/tests/snapshots.rs
 expression: stdout
 ---
+⚠ nonexistent.rs  file not found
 ✔ 0 files ok

--- a/crates/loq_cli/tests/snapshots/snapshots__no_config_uses_defaults.snap
+++ b/crates/loq_cli/tests/snapshots/snapshots__no_config_uses_defaults.snap
@@ -2,4 +2,4 @@
 source: crates/loq_cli/tests/snapshots.rs
 expression: stdout
 ---
-✔ 1 files ok
+✔ 1 file ok


### PR DESCRIPTION
`loq check missing.rs` used to succeed without showing anything about the missing explicit path, and one-file success output printed `1 files ok`.

This makes missing explicit paths visible in default text output while keeping binary and unreadable skip warnings behind verbose mode. It also fixes singular success grammar and updates the README wording so token budgets are no longer contradicted by the project pitch.

Validated with `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, `cargo run -p loq -- check .`, and `uvx prek run -a`.