### PR TITLE
refactor: dedup baseline/tighten/relax commands

### DIFF
--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -7,12 +7,13 @@ use anyhow::Result;
 use termcolor::WriteColor;
 use toml_edit::DocumentMut;
 
-use crate::baseline_shared::scan_violations_with_threshold;
+use crate::baseline_shared::{finish, scan_violations_with_threshold, ChangeReport};
 use crate::cli::BaselineArgs;
 use crate::config_edit::{load_doc_or_default, persist_doc, threshold_from_doc};
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::output::{
-    change_style, max_formatted_width, print_error, write_change_row, ChangeKind, ChangeRow,
+    change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
+    ChangeRow, ChangeStyle,
 };
 use crate::ExitStatus;
 
@@ -20,9 +21,13 @@ struct BaselineReport {
     changes: Vec<ChangeRow>,
 }
 
-impl BaselineReport {
+impl ChangeReport for BaselineReport {
     fn is_empty(&self) -> bool {
         self.changes.is_empty()
+    }
+
+    fn write<W: WriteColor>(&self, writer: &mut W) -> std::io::Result<()> {
+        write_report(writer, self)
     }
 }
 
@@ -31,17 +36,7 @@ pub fn run_baseline<W1: WriteColor, W2: WriteColor>(
     stdout: &mut W1,
     stderr: &mut W2,
 ) -> ExitStatus {
-    match run_baseline_inner(args) {
-        Ok(report) => {
-            if report.is_empty() {
-                let _ = writeln!(stdout, "✔ No changes needed");
-                return ExitStatus::Success;
-            }
-            let _ = write_report(stdout, &report);
-            ExitStatus::Success
-        }
-        Err(err) => print_error(stderr, &format!("{err:#}")),
-    }
+    finish(run_baseline_inner(args), stdout, stderr)
 }
 
 fn run_baseline_inner(args: &BaselineArgs) -> Result<BaselineReport> {
@@ -139,29 +134,19 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &BaselineReport) -> std::
     let counts = write_change_lines(writer, &changes, width, &style)?;
 
     if counts.added > 0 || counts.updated > 0 {
-        writer.set_color(&style.ok)?;
-        write!(writer, "✔ ")?;
-        writer.reset()?;
-        writer.set_color(&style.dimmed)?;
-        let output = capitalize_first(&change_summary(&counts));
-        write!(writer, "{output}")?;
-        writer.reset()?;
-        writeln!(writer)?;
+        write_ok_line(writer, &style, &capitalize_first(&change_summary(&counts)))?;
     }
 
     if counts.removed > 0 {
-        writer.set_color(&style.ok)?;
-        write!(writer, "✔ ")?;
-        writer.reset()?;
-        writer.set_color(&style.dimmed)?;
-        write!(
+        write_ok_line(
             writer,
-            "Removed limits for {} file{}",
-            counts.removed,
-            if counts.removed == 1 { "" } else { "s" }
+            &style,
+            &format!(
+                "Removed limits for {} file{}",
+                counts.removed,
+                plural(counts.removed)
+            ),
         )?;
-        writer.reset()?;
-        writeln!(writer)?;
     }
 
     Ok(())
@@ -192,7 +177,7 @@ fn write_change_lines<W: WriteColor>(
     writer: &mut W,
     changes: &[&ChangeRow],
     width: usize,
-    style: &crate::output::ChangeStyle,
+    style: &ChangeStyle,
 ) -> std::io::Result<ChangeCounts> {
     let mut counts = ChangeCounts {
         added: 0,
@@ -229,14 +214,14 @@ fn change_summary(counts: &ChangeCounts) -> String {
         parts.push(format!(
             "added {} file{}",
             counts.added,
-            if counts.added == 1 { "" } else { "s" }
+            plural(counts.added)
         ));
     }
     if counts.updated > 0 {
         parts.push(format!(
             "updated {} file{}",
             counts.updated,
-            if counts.updated == 1 { "" } else { "s" }
+            plural(counts.updated)
         ));
     }
     parts.join(", ")

--- a/crates/loq_cli/src/baseline_shared.rs
+++ b/crates/loq_cli/src/baseline_shared.rs
@@ -5,10 +5,55 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use loq_core::config::DEFAULT_RESPECT_GITIGNORE;
+use loq_core::{FileOutcome, Metric, OutcomeKind};
 use loq_fs::CheckOptions;
+use termcolor::WriteColor;
 use toml_edit::{DocumentMut, Item};
 
 use crate::exact_limits::{extract_paths, is_exact_path};
+use crate::output::print_error;
+use crate::ExitStatus;
+
+/// A change report produced by a baseline-style command.
+pub(crate) trait ChangeReport {
+    /// Returns true when the command made no changes.
+    fn is_empty(&self) -> bool;
+    /// Writes the human-readable change summary.
+    fn write<W: WriteColor>(&self, writer: &mut W) -> std::io::Result<()>;
+}
+
+/// Prints a change report (or error) and returns the process exit status.
+pub(crate) fn finish<W1: WriteColor, W2: WriteColor, R: ChangeReport>(
+    result: Result<R>,
+    stdout: &mut W1,
+    stderr: &mut W2,
+) -> ExitStatus {
+    match result {
+        Ok(report) if report.is_empty() => {
+            let _ = writeln!(stdout, "✔ No changes needed");
+            ExitStatus::Success
+        }
+        Ok(report) => {
+            let _ = report.write(stdout);
+            ExitStatus::Success
+        }
+        Err(err) => print_error(stderr, &format!("{err:#}")),
+    }
+}
+
+/// Collects line-metric violations keyed by match key.
+pub(crate) fn line_violations(outcomes: &[FileOutcome]) -> HashMap<String, usize> {
+    outcomes.iter().filter_map(line_violation).collect()
+}
+
+fn line_violation(outcome: &FileOutcome) -> Option<(String, usize)> {
+    if let OutcomeKind::Violation { actual, limit, .. } = &outcome.kind {
+        if limit.metric == Metric::Lines {
+            return Some((outcome.match_key.clone(), *actual));
+        }
+    }
+    None
+}
 
 /// Find all files that violate the given threshold.
 pub(crate) fn scan_violations_with_threshold(
@@ -34,18 +79,12 @@ pub(crate) fn scan_violations_with_threshold(
         .canonicalize()
         .unwrap_or_else(|_| temp_file.path().to_path_buf());
 
-    let mut violations = HashMap::new();
-    for outcome in output.outcomes {
-        if outcome.path == temp_config_path {
-            continue;
-        }
-
-        if let loq_core::OutcomeKind::Violation { actual, limit, .. } = outcome.kind {
-            if limit.metric == loq_core::Metric::Lines {
-                violations.insert(outcome.match_key, actual);
-            }
-        }
-    }
+    let violations = output
+        .outcomes
+        .iter()
+        .filter(|outcome| outcome.path != temp_config_path)
+        .filter_map(line_violation)
+        .collect();
 
     Ok(violations)
 }
@@ -93,7 +132,46 @@ fn build_temp_config(doc: &DocumentMut, threshold: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use loq_core::{ConfigOrigin, Limit, MatchBy};
+    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    fn violation(match_key: &str, limit: Limit, actual: usize) -> FileOutcome {
+        FileOutcome {
+            path: PathBuf::from(match_key),
+            display_path: match_key.into(),
+            match_key: match_key.into(),
+            config_source: ConfigOrigin::BuiltIn,
+            kind: OutcomeKind::Violation {
+                limit,
+                actual,
+                matched_by: MatchBy::Default,
+            },
+        }
+    }
+
+    #[test]
+    fn line_violations_keys_by_match_key() {
+        let mut pass = violation("src/b.rs", Limit::lines(10), 9);
+        pass.kind = OutcomeKind::Pass {
+            limit: Limit::lines(10),
+            actual: 9,
+            matched_by: MatchBy::Default,
+        };
+        let outcomes = vec![violation("src/a.rs", Limit::lines(10), 12), pass];
+
+        let violations = line_violations(&outcomes);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations.get("src/a.rs"), Some(&12));
+    }
+
+    #[test]
+    fn line_violations_ignores_token_violations() {
+        let outcomes = vec![violation("prompt.md", Limit::tokens(4), 5)];
+
+        assert!(line_violations(&outcomes).is_empty());
+    }
 
     #[test]
     fn build_temp_config_keeps_glob_rules_only() {

--- a/crates/loq_cli/src/output/mod.rs
+++ b/crates/loq_cli/src/output/mod.rs
@@ -94,6 +94,31 @@ where
         .fold(6, |current, value| current.max(format_number(value).len()))
 }
 
+/// Returns the plural suffix (`""` or `"s"`) for `count`.
+#[must_use]
+pub const fn plural(count: usize) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Writes a dimmed summary line prefixed with a green check mark.
+pub fn write_ok_line<W: WriteColor>(
+    writer: &mut W,
+    style: &ChangeStyle,
+    text: &str,
+) -> io::Result<()> {
+    writer.set_color(&style.ok)?;
+    write!(writer, "✔ ")?;
+    writer.reset()?;
+    writer.set_color(&style.dimmed)?;
+    write!(writer, "{text}")?;
+    writer.reset()?;
+    writeln!(writer)
+}
+
 pub fn write_change_row<W: WriteColor>(
     writer: &mut W,
     style: &ChangeStyle,
@@ -287,19 +312,23 @@ pub fn write_block<W: WriteColor>(
 
 pub fn write_summary<W: WriteColor>(writer: &mut W, summary: &Summary) -> io::Result<()> {
     if summary.errors > 0 {
-        let word = if summary.errors == 1 {
-            "violation"
-        } else {
-            "violations"
-        };
         writer.set_color(&fg(Color::Red))?;
-        writeln!(writer, "{} {word}", summary.errors)?;
+        writeln!(
+            writer,
+            "{} violation{}",
+            summary.errors,
+            plural(summary.errors)
+        )?;
     } else {
         writer.set_color(&fg(Color::Green))?;
         write!(writer, "✔")?;
         writer.reset()?;
-        let word = if summary.passed == 1 { "file" } else { "files" };
-        writeln!(writer, " {} {word} ok", format_number(summary.passed))?;
+        writeln!(
+            writer,
+            " {} file{} ok",
+            format_number(summary.passed),
+            plural(summary.passed)
+        )?;
     }
     writer.reset()
 }

--- a/crates/loq_cli/src/relax.rs
+++ b/crates/loq_cli/src/relax.rs
@@ -8,11 +8,13 @@ use loq_fs::CheckOptions;
 use termcolor::WriteColor;
 use toml_edit::DocumentMut;
 
+use crate::baseline_shared::{finish, line_violations, ChangeReport};
 use crate::cli::RelaxArgs;
 use crate::config_edit::{load_doc_or_default, persist_doc};
 use crate::exact_limits::{self, ExactLimits};
 use crate::output::{
-    change_style, max_formatted_width, print_error, write_change_row, ChangeKind, ChangeRow,
+    change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
+    ChangeRow,
 };
 use crate::ExitStatus;
 
@@ -20,9 +22,13 @@ struct RelaxReport {
     changes: Vec<ChangeRow>,
 }
 
-impl RelaxReport {
+impl ChangeReport for RelaxReport {
     fn is_empty(&self) -> bool {
         self.changes.is_empty()
+    }
+
+    fn write<W: WriteColor>(&self, writer: &mut W) -> std::io::Result<()> {
+        write_report(writer, self)
     }
 }
 
@@ -31,17 +37,7 @@ pub fn run_relax<W1: WriteColor, W2: WriteColor>(
     stdout: &mut W1,
     stderr: &mut W2,
 ) -> ExitStatus {
-    match run_relax_inner(args) {
-        Ok(report) => {
-            if report.is_empty() {
-                let _ = writeln!(stdout, "✔ No changes needed");
-                return ExitStatus::Success;
-            }
-            let _ = write_report(stdout, &report);
-            ExitStatus::Success
-        }
-        Err(err) => print_error(stderr, &format!("{err:#}")),
-    }
+    finish(run_relax_inner(args), stdout, stderr)
 }
 
 fn run_relax_inner(args: &RelaxArgs) -> Result<RelaxReport> {
@@ -62,7 +58,7 @@ fn run_relax_inner(args: &RelaxArgs) -> Result<RelaxReport> {
     };
 
     let output = loq_fs::run_check(paths, options).context("relax check failed")?;
-    let violations = collect_violations(&output.outcomes);
+    let violations = line_violations(&output.outcomes);
 
     if violations.is_empty() {
         return Ok(RelaxReport {
@@ -78,18 +74,6 @@ fn run_relax_inner(args: &RelaxArgs) -> Result<RelaxReport> {
     persist_doc(&cwd, &config_path, &doc, config_exists_for_write)?;
 
     Ok(RelaxReport { changes })
-}
-
-fn collect_violations(outcomes: &[loq_core::FileOutcome]) -> HashMap<String, usize> {
-    let mut violations = HashMap::new();
-    for outcome in outcomes {
-        if let loq_core::OutcomeKind::Violation { actual, limit, .. } = outcome.kind {
-            if limit.metric == loq_core::Metric::Lines {
-                violations.insert(outcome.match_key.clone(), actual);
-            }
-        }
-    }
-    violations
 }
 
 fn apply_relax_changes(
@@ -139,80 +123,18 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &RelaxReport) -> std::io:
             &change.path,
         )?;
     }
-    writer.set_color(&style.ok)?;
-    write!(writer, "✔ ")?;
-    writer.reset()?;
-    writer.set_color(&style.dimmed)?;
-    write!(
+    write_ok_line(
         writer,
-        "Relaxed limits for {count} file{}",
-        if count == 1 { "" } else { "s" }
-    )?;
-    writer.reset()?;
-    writeln!(writer)?;
-    Ok(())
+        &style,
+        &format!("Relaxed limits for {count} file{}", plural(count)),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loq_core::report::OutcomeKind;
-    use loq_core::{ConfigOrigin, MatchBy};
-    use std::collections::HashMap;
-    use std::path::PathBuf;
     use termcolor::NoColor;
     use toml_edit::Item;
-
-    #[test]
-    fn collect_violations_uses_match_key() {
-        let outcomes = vec![
-            loq_core::FileOutcome {
-                path: PathBuf::from("/tmp/a"),
-                display_path: "./src/a.rs".into(),
-                match_key: "src/a.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
-                kind: OutcomeKind::Violation {
-                    limit: loq_core::Limit::lines(10),
-                    actual: 12,
-                    matched_by: MatchBy::Default,
-                },
-            },
-            loq_core::FileOutcome {
-                path: PathBuf::from("/tmp/b"),
-                display_path: "src/b.rs".into(),
-                match_key: "src/b.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
-                kind: OutcomeKind::Pass {
-                    limit: loq_core::Limit::lines(10),
-                    actual: 9,
-                    matched_by: MatchBy::Default,
-                },
-            },
-        ];
-
-        let violations = collect_violations(&outcomes);
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations.get("src/a.rs"), Some(&12));
-    }
-
-    #[test]
-    fn collect_violations_ignores_token_violations() {
-        let outcomes = vec![loq_core::FileOutcome {
-            path: PathBuf::from("/tmp/prompt"),
-            display_path: "prompt.md".into(),
-            match_key: "prompt.md".into(),
-            config_source: ConfigOrigin::BuiltIn,
-            kind: OutcomeKind::Violation {
-                limit: loq_core::Limit::tokens(4),
-                actual: 5,
-                matched_by: MatchBy::Default,
-            },
-        }];
-
-        let violations = collect_violations(&outcomes);
-
-        assert!(violations.is_empty());
-    }
 
     #[test]
     fn apply_relax_changes_updates_and_adds_rules() {

--- a/crates/loq_cli/src/tighten.rs
+++ b/crates/loq_cli/src/tighten.rs
@@ -7,12 +7,13 @@ use anyhow::Result;
 use termcolor::WriteColor;
 use toml_edit::DocumentMut;
 
-use crate::baseline_shared::scan_violations_with_threshold;
+use crate::baseline_shared::{finish, scan_violations_with_threshold, ChangeReport};
 use crate::cli::TightenArgs;
 use crate::config_edit::{load_doc_or_default, persist_doc, threshold_from_doc};
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::output::{
-    change_style, max_formatted_width, print_error, write_change_row, ChangeKind, ChangeRow,
+    change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
+    ChangeRow,
 };
 use crate::ExitStatus;
 
@@ -21,9 +22,13 @@ struct TightenReport {
     removed: usize,
 }
 
-impl TightenReport {
+impl ChangeReport for TightenReport {
     fn is_empty(&self) -> bool {
         self.changes.is_empty() && self.removed == 0
+    }
+
+    fn write<W: WriteColor>(&self, writer: &mut W) -> std::io::Result<()> {
+        write_report(writer, self)
     }
 }
 
@@ -32,17 +37,7 @@ pub fn run_tighten<W1: WriteColor, W2: WriteColor>(
     stdout: &mut W1,
     stderr: &mut W2,
 ) -> ExitStatus {
-    match run_tighten_inner(args) {
-        Ok(report) => {
-            if report.is_empty() {
-                let _ = writeln!(stdout, "✔ No changes needed");
-                return ExitStatus::Success;
-            }
-            let _ = write_report(stdout, &report);
-            ExitStatus::Success
-        }
-        Err(err) => print_error(stderr, &format!("{err:#}")),
-    }
+    finish(run_tighten_inner(args), stdout, stderr)
 }
 
 fn run_tighten_inner(args: &TightenArgs) -> Result<TightenReport> {
@@ -117,32 +112,23 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &TightenReport) -> std::i
         }
 
         let count = report.changes.len();
-        writer.set_color(&style.ok)?;
-        write!(writer, "✔ ")?;
-        writer.reset()?;
-        writer.set_color(&style.dimmed)?;
-        write!(
+        write_ok_line(
             writer,
-            "Tightened limits for {count} file{}",
-            if count == 1 { "" } else { "s" }
+            &style,
+            &format!("Tightened limits for {count} file{}", plural(count)),
         )?;
-        writer.reset()?;
-        writeln!(writer)?;
     }
 
     if report.removed > 0 {
-        writer.set_color(&style.ok)?;
-        write!(writer, "✔ ")?;
-        writer.reset()?;
-        writer.set_color(&style.dimmed)?;
-        write!(
+        write_ok_line(
             writer,
-            "Removed limits for {} file{}",
-            report.removed,
-            if report.removed == 1 { "" } else { "s" }
+            &style,
+            &format!(
+                "Removed limits for {} file{}",
+                report.removed,
+                plural(report.removed)
+            ),
         )?;
-        writer.reset()?;
-        writeln!(writer)?;
     }
 
     Ok(())


### PR DESCRIPTION
First in a stack of 5 cleanup/feature PRs. Base: `main`.

The three change-applying commands (`baseline`, `tighten`, `relax`) had drifted into near-identical shells around small differences in logic. This pulls the shared structure into `baseline_shared`:

- A `ChangeReport` trait plus a `finish()` helper collapse the three identical `run_*` wrappers (the `match` that prints "No changes needed", writes the report, or reports an error).
- `line_violations()` replaces relax's `collect_violations` and the inline loop in `scan_violations_with_threshold`.

Two small output helpers remove repetition that was copy-pasted across all three: `plural()` for the `if n == 1 { "" } else { "s" }` dance, and `write_ok_line()` for the six-line set-color/✔/dimmed/reset summary block.

No behavior change — output is byte-identical and the snapshots are untouched. The command files shrink noticeably.