### PR TITLE
docs: remove step-by-step narration comments

### DIFF
--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -43,23 +43,13 @@ fn run_baseline_inner(args: &BaselineArgs) -> Result<BaselineReport> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let config_path = cwd.join("loq.toml");
 
-    // Step 1: Read and parse the config file (or create defaults if missing)
     let (mut doc, config_exists) = load_doc_or_default(&config_path)?;
-
-    // Step 2: Determine threshold (--threshold or default_max_lines from config)
     let threshold = threshold_from_doc(&doc, args.threshold);
-
-    // Step 3: Run check to find violations (respects config's exclude and gitignore settings)
     let violations =
         scan_violations_with_threshold(&cwd, &doc, threshold, "baseline check failed")?;
-
-    // Step 4: Collect existing exact-path rules (baseline candidates)
     let existing_rules = ExactLimits::collect(&doc);
-
-    // Step 5: Compute changes
     let report = apply_baseline_changes(&mut doc, &violations, &existing_rules);
 
-    // Step 6: Write config back
     persist_doc(&cwd, &config_path, &doc, config_exists)?;
 
     Ok(report)

--- a/crates/loq_cli/src/output/mod.rs
+++ b/crates/loq_cli/src/output/mod.rs
@@ -184,12 +184,11 @@ pub fn write_finding<W: WriteColor>(
         FindingKind::SkipWarning { .. } => ("⚠", Color::Yellow),
     };
 
-    // Symbol
     writer.set_color(&fg(color))?;
     write!(writer, "{symbol} ")?;
     writer.reset()?;
 
-    // Details first (fixed-width), then path (variable-width)
+    // Fixed-width measurement columns first, then the variable-width path.
     match &finding.kind {
         FindingKind::Violation {
             actual,
@@ -197,8 +196,7 @@ pub fn write_finding<W: WriteColor>(
             matched_by,
             ..
         } => {
-            // Format: ✖ 1,427 > 500  path/to/file.rs
-            // Right-align actual within 6 chars (handles up to 99,999)
+            // e.g. `✖ 1_427 > 500  path/to/file.rs`
             let actual_str = formatted_measurement(*actual, *limit);
             let limit_str = format_number(limit.max);
             writer.set_color(&fg(color).set_bold(true).clone())?;

--- a/crates/loq_fs/src/lib.rs
+++ b/crates/loq_fs/src/lib.rs
@@ -93,7 +93,6 @@ fn load_config_from_path(path: &Path, fallback_cwd: &Path) -> Result<CompiledCon
 ///
 /// Exclusion filtering (gitignore + exclude patterns) happens at the walk layer.
 pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutput, FsError> {
-    // Step 1: Load config (explicit path, discovered, or built-in defaults)
     let compiled = if let Some(ref config_path) = options.config_path {
         load_config_from_path(config_path, &options.cwd)?
     } else if let Some(config_path) = discover::find_config(&options.cwd) {
@@ -107,7 +106,7 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
         compile_config(ConfigOrigin::BuiltIn, root_dir, config, None)?
     };
 
-    // Step 2: Load cache (if enabled) - cache lives at config root
+    // The cache lives at the config root.
     let config_hash = cache::hash_config(&compiled);
     let file_cache = if options.use_cache {
         cache::Cache::load(&compiled.root_dir, config_hash)
@@ -116,13 +115,12 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
     };
     let inspector = Inspector::new(file_cache);
 
-    // Step 3: Canonicalize cwd once (instead of per-file)
+    // Canonicalize once here rather than per file.
     let cwd_abs = options
         .cwd
         .canonicalize()
         .unwrap_or_else(|_| options.cwd.clone());
 
-    // Step 4: Walk paths, filtering through gitignore + exclude patterns
     let walk_options = walk::WalkOptions {
         respect_gitignore: compiled.respect_gitignore,
         exclude: compiled.exclude_patterns(),
@@ -135,10 +133,8 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
     file_list.sort();
     file_list.dedup();
 
-    // Step 5: Check all files in parallel
     let outcomes = check_group(&file_list, &compiled, &cwd_abs, &inspector);
 
-    // Step 6: Save cache (if enabled) - cache lives at config root
     if options.use_cache {
         if let Some(cache) = inspector.into_cache() {
             cache.save(&compiled.root_dir);


### PR DESCRIPTION
Stacked on #60.

Strips the `// Step 1/2/3...` comments in `run_check` and `run_baseline_inner` that just restated the next line of plainly sequential code. The two genuinely useful notes (cache lives at the config root; canonicalize once rather than per-file) are kept, reworded.

Also fixes a stale comment in `write_finding`: the example showed comma-separated numbers the formatter never emits (it uses `_`), and the "handles up to 99,999" claim was wrong since the column width is a floor, not a cap.

Comments only — no code changes.