### PR TITLE
fix: baseline/relax/tighten discover the config like check does

### DIFF
--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -9,7 +9,7 @@ use toml_edit::DocumentMut;
 
 use crate::baseline_shared::{finish, scan_violations_with_threshold, ChangeReport};
 use crate::cli::BaselineArgs;
-use crate::config_edit::{load_doc_or_default, persist_doc, threshold_from_doc};
+use crate::config_edit::{load_doc_or_default, locate_config, persist_doc, threshold_from_doc};
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::output::{
     change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
@@ -41,16 +41,16 @@ pub fn run_baseline<W1: WriteColor, W2: WriteColor>(
 
 fn run_baseline_inner(args: &BaselineArgs) -> Result<BaselineReport> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let config_path = cwd.join("loq.toml");
+    let (config_path, root) = locate_config(&cwd);
 
     let (mut doc, config_exists) = load_doc_or_default(&config_path)?;
     let threshold = threshold_from_doc(&doc, args.threshold);
     let violations =
-        scan_violations_with_threshold(&cwd, &doc, threshold, "baseline check failed")?;
+        scan_violations_with_threshold(&root, &doc, threshold, "baseline check failed")?;
     let existing_rules = ExactLimits::collect(&doc);
     let report = apply_baseline_changes(&mut doc, &violations, &existing_rules);
 
-    persist_doc(&cwd, &config_path, &doc, config_exists)?;
+    persist_doc(&root, &config_path, &doc, config_exists)?;
 
     Ok(report)
 }

--- a/crates/loq_cli/src/config_edit.rs
+++ b/crates/loq_cli/src/config_edit.rs
@@ -1,12 +1,28 @@
 //! Shared helpers for editing `loq.toml` with `toml_edit`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use loq_core::config::{DEFAULT_MAX_LINES, DEFAULT_RESPECT_GITIGNORE};
 use toml_edit::{DocumentMut, Item};
 
 use crate::init::add_to_gitignore;
+
+/// Locates the `loq.toml` an edit command should operate on, plus the
+/// directory that governs it.
+///
+/// Walks up from `cwd` to find an existing config (matching how `check`
+/// discovers one); falls back to `cwd/loq.toml` when none exists. The
+/// returned directory is the config's parent — the root that exact-path
+/// rule keys are relative to — so edits land in the project's real config
+/// instead of spawning a stray one in a subdirectory.
+pub(crate) fn locate_config(cwd: &Path) -> (PathBuf, PathBuf) {
+    let path = loq_fs::discover::find_config(cwd).unwrap_or_else(|| cwd.join("loq.toml"));
+    let root = path
+        .parent()
+        .map_or_else(|| cwd.to_path_buf(), Path::to_path_buf);
+    (path, root)
+}
 
 /// Create a default document for initializing `loq.toml`.
 pub(crate) fn default_document() -> DocumentMut {

--- a/crates/loq_cli/src/relax.rs
+++ b/crates/loq_cli/src/relax.rs
@@ -10,7 +10,7 @@ use toml_edit::DocumentMut;
 
 use crate::baseline_shared::{finish, line_violations, ChangeReport};
 use crate::cli::RelaxArgs;
-use crate::config_edit::{load_doc_or_default, persist_doc};
+use crate::config_edit::{load_doc_or_default, locate_config, persist_doc};
 use crate::exact_limits::{self, ExactLimits};
 use crate::output::{
     change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
@@ -42,18 +42,18 @@ pub fn run_relax<W1: WriteColor, W2: WriteColor>(
 
 fn run_relax_inner(args: &RelaxArgs) -> Result<RelaxReport> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let config_path = cwd.join("loq.toml");
+    let (config_path, root) = locate_config(&cwd);
     let config_exists = config_path.exists();
 
     let paths = if args.files.is_empty() {
-        vec![cwd.clone()]
+        vec![root.clone()]
     } else {
         args.files.clone()
     };
 
     let options = CheckOptions {
         config_path: config_exists.then(|| config_path.clone()),
-        cwd: cwd.clone(),
+        cwd,
         use_cache: false,
     };
 
@@ -71,7 +71,7 @@ fn run_relax_inner(args: &RelaxArgs) -> Result<RelaxReport> {
     let existing_rules = ExactLimits::collect(&doc);
     let changes = apply_relax_changes(&mut doc, &violations, &existing_rules, args.extra);
 
-    persist_doc(&cwd, &config_path, &doc, config_exists_for_write)?;
+    persist_doc(&root, &config_path, &doc, config_exists_for_write)?;
 
     Ok(RelaxReport { changes })
 }

--- a/crates/loq_cli/src/tighten.rs
+++ b/crates/loq_cli/src/tighten.rs
@@ -9,7 +9,7 @@ use toml_edit::DocumentMut;
 
 use crate::baseline_shared::{finish, scan_violations_with_threshold, ChangeReport};
 use crate::cli::TightenArgs;
-use crate::config_edit::{load_doc_or_default, persist_doc, threshold_from_doc};
+use crate::config_edit::{load_doc_or_default, locate_config, persist_doc, threshold_from_doc};
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::output::{
     change_style, max_formatted_width, plural, write_change_row, write_ok_line, ChangeKind,
@@ -42,16 +42,17 @@ pub fn run_tighten<W1: WriteColor, W2: WriteColor>(
 
 fn run_tighten_inner(args: &TightenArgs) -> Result<TightenReport> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let config_path = cwd.join("loq.toml");
+    let (config_path, root) = locate_config(&cwd);
 
     let (mut doc, config_exists) = load_doc_or_default(&config_path)?;
     let threshold = threshold_from_doc(&doc, args.threshold);
 
-    let violations = scan_violations_with_threshold(&cwd, &doc, threshold, "tighten check failed")?;
+    let violations =
+        scan_violations_with_threshold(&root, &doc, threshold, "tighten check failed")?;
     let existing_rules = ExactLimits::collect(&doc);
     let report = apply_tighten_changes(&mut doc, &violations, &existing_rules);
 
-    persist_doc(&cwd, &config_path, &doc, config_exists)?;
+    persist_doc(&root, &config_path, &doc, config_exists)?;
 
     Ok(report)
 }

--- a/crates/loq_cli/tests/config_discovery.rs
+++ b/crates/loq_cli/tests/config_discovery.rs
@@ -1,0 +1,93 @@
+//! Edit commands discover the config upward instead of spawning a stray one.
+
+use std::path::Path;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::TempDir;
+
+fn write_file(dir: &Path, path: &str, contents: &str) {
+    let full = dir.join(path);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(full, contents).unwrap();
+}
+
+fn repeat_lines(count: usize) -> String {
+    "line\n".repeat(count)
+}
+
+#[test]
+fn baseline_from_subdir_edits_root_config() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("loq.toml"), "default_max_lines = 500\n").unwrap();
+    write_file(root, "pkg/legacy.txt", &repeat_lines(501));
+
+    cargo_bin_cmd!("loq")
+        .current_dir(root.join("pkg"))
+        .args(["baseline"])
+        .assert()
+        .success();
+
+    assert!(
+        !root.join("pkg/loq.toml").exists(),
+        "baseline created a stray config in the subdirectory"
+    );
+    let config = std::fs::read_to_string(root.join("loq.toml")).unwrap();
+    assert!(
+        config.contains("\"pkg/legacy.txt\""),
+        "config was: {config}"
+    );
+    assert!(config.contains("max_lines = 501"), "config was: {config}");
+}
+
+#[test]
+fn relax_from_subdir_edits_root_config() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("loq.toml"), "default_max_lines = 500\n").unwrap();
+    write_file(root, "pkg/legacy.txt", &repeat_lines(600));
+
+    cargo_bin_cmd!("loq")
+        .current_dir(root.join("pkg"))
+        .args(["relax"])
+        .assert()
+        .success();
+
+    assert!(
+        !root.join("pkg/loq.toml").exists(),
+        "relax created a stray config in the subdirectory"
+    );
+    let config = std::fs::read_to_string(root.join("loq.toml")).unwrap();
+    assert!(
+        config.contains("\"pkg/legacy.txt\""),
+        "config was: {config}"
+    );
+    assert!(config.contains("max_lines = 600"), "config was: {config}");
+}
+
+#[test]
+fn tighten_from_subdir_edits_root_config() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    std::fs::write(
+        root.join("loq.toml"),
+        "default_max_lines = 500\n\n[[rules]]\npath = \"pkg/legacy.txt\"\nmax_lines = 900\n",
+    )
+    .unwrap();
+    write_file(root, "pkg/legacy.txt", &repeat_lines(600));
+
+    cargo_bin_cmd!("loq")
+        .current_dir(root.join("pkg"))
+        .args(["tighten"])
+        .assert()
+        .success();
+
+    assert!(
+        !root.join("pkg/loq.toml").exists(),
+        "tighten created a stray config in the subdirectory"
+    );
+    let config = std::fs::read_to_string(root.join("loq.toml")).unwrap();
+    assert!(config.contains("max_lines = 600"), "config was: {config}");
+}


### PR DESCRIPTION
Stacked on #61.

`check` finds `loq.toml` by walking up the directory tree, but the edit commands always targeted `cwd/loq.toml`. So running `loq baseline` (or `relax`/`tighten`) from a subdirectory of a configured project created a stray `loq.toml` in that subdirectory instead of editing the real one above. `relax` was worse — it checked against the discovered parent config while writing rules into a brand-new child.

This adds `config_edit::locate_config`, which walks up from cwd to find an existing config (matching `check`'s discovery) and returns the config's directory as the operating root. All three commands now scan and write exact-path rules relative to that root, so the keys line up with what `check` later reads. When no config exists, behavior is unchanged: it targets `cwd/loq.toml`.

Includes regression tests running each command from a subdirectory and asserting the parent config is edited and no stray child is created.