### PR TITLE
refactor: use div_ceil for token estimate

### DIFF
--- a/crates/loq_fs/src/inspection.rs
+++ b/crates/loq_fs/src/inspection.rs
@@ -103,13 +103,9 @@ fn cached_result_to_outcome(
 const fn measurement_for_limit(lines: usize, bytes: usize, limit: Limit) -> usize {
     match limit.metric {
         Metric::Lines => lines,
-        Metric::Tokens => {
-            if bytes % 4 == 0 {
-                bytes / 4
-            } else {
-                bytes / 4 + 1
-            }
-        }
+        // Deliberate bytes/4 heuristic, not a real tokenizer; rounded up so
+        // any non-empty file counts as at least one token.
+        Metric::Tokens => bytes.div_ceil(4),
     }
 }
 


### PR DESCRIPTION
Stacked on #62.

Replaces the manual `bytes % 4` ceiling with `bytes.div_ceil(4)`, and adds a one-line note that the `bytes / 4` token count is a deliberate heuristic, not a real tokenizer. No behavior change.