### PR TITLE
feat: support default_max_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ loq works zero-config. Run `loq init` to create a `loq.toml` file to customize:
 # default, for files not matching any rule
 default_max_lines = 500
 
+# Or default to an approximate token budget instead of lines.
+# Set only one of default_max_lines / default_max_tokens.
+# default_max_tokens = 8000
+
 # skip .gitignore'd files
 respect_gitignore = true
 

--- a/crates/loq_cli/tests/default_token_budget.rs
+++ b/crates/loq_cli/tests/default_token_budget.rs
@@ -1,0 +1,40 @@
+//! A global `default_max_tokens` applies to files matching no rule.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn default_max_tokens_flags_unmatched_file() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("loq.toml"), "default_max_tokens = 4\n").unwrap();
+    // 20 bytes -> ceil(20 / 4) = 5 tokens, over the budget of 4.
+    std::fs::write(temp.path().join("big.txt"), "abcdefghijklmnopqrs\n").unwrap();
+
+    cargo_bin_cmd!("loq")
+        .current_dir(temp.path())
+        .arg("check")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("tokens"));
+}
+
+#[test]
+fn both_default_budgets_is_an_error() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("loq.toml"),
+        "default_max_lines = 100\ndefault_max_tokens = 4\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("a.txt"), "hi\n").unwrap();
+
+    cargo_bin_cmd!("loq")
+        .current_dir(temp.path())
+        .arg("check")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "only one of default_max_lines or default_max_tokens",
+        ));
+}

--- a/crates/loq_core/src/config.rs
+++ b/crates/loq_core/src/config.rs
@@ -50,6 +50,8 @@ where
 pub struct LoqConfig {
     /// Default line limit for files not matching any rule.
     pub default_max_lines: Option<usize>,
+    /// Default approximate token limit for files not matching any rule.
+    pub default_max_tokens: Option<usize>,
     /// Whether to skip files matched by `.gitignore`.
     #[serde(default = "default_respect_gitignore")]
     pub respect_gitignore: bool,
@@ -68,6 +70,7 @@ impl Default for LoqConfig {
     fn default() -> Self {
         Self {
             default_max_lines: Some(DEFAULT_MAX_LINES),
+            default_max_tokens: None,
             respect_gitignore: DEFAULT_RESPECT_GITIGNORE,
             exclude: Vec::new(),
             rules: Vec::new(),
@@ -287,6 +290,7 @@ pub fn compile_config(
         source_path.map_or_else(|| PathBuf::from("<built-in defaults>"), Path::to_path_buf);
 
     let exclude = compile_patterns(&config.exclude, &path_for_errors)?;
+    let default_limit = default_limit(&config, &path_for_errors)?;
     let mut rules = Vec::new();
     for rule in config.rules {
         let mut matchers = Vec::new();
@@ -304,12 +308,24 @@ pub fn compile_config(
     Ok(CompiledConfig {
         origin,
         root_dir,
-        default_limit: config.default_max_lines.map(Limit::lines),
+        default_limit,
         respect_gitignore: config.respect_gitignore,
         fix_guidance: config.fix_guidance,
         exclude,
         rules,
     })
+}
+
+fn default_limit(config: &LoqConfig, source_path: &Path) -> Result<Option<Limit>, ConfigError> {
+    match (config.default_max_lines, config.default_max_tokens) {
+        (Some(_), Some(_)) => Err(ConfigError::InvalidLimit {
+            path: source_path.to_path_buf(),
+            message: "set only one of default_max_lines or default_max_tokens".to_string(),
+        }),
+        (Some(lines), None) => Ok(Some(Limit::lines(lines))),
+        (None, Some(tokens)) => Ok(Some(Limit::tokens(tokens))),
+        (None, None) => Ok(None),
+    }
 }
 
 fn rule_limit(rule: &Rule, source_path: &Path) -> Result<Limit, ConfigError> {

--- a/crates/loq_core/src/config/tests.rs
+++ b/crates/loq_core/src/config/tests.rs
@@ -31,6 +31,7 @@ fn init_template_has_rules() {
 fn invalid_glob_reports_error() {
     let config = LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![Rule {
@@ -51,6 +52,7 @@ fn invalid_glob_reports_error() {
 fn glob_error_display_is_stable() {
     let config = LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec!["[[".to_string()],
         rules: vec![],
@@ -64,6 +66,7 @@ fn glob_error_display_is_stable() {
 fn glob_star_does_not_cross_directories() {
     let config = LoqConfig {
         default_max_lines: None,
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![Rule {
@@ -84,6 +87,7 @@ fn glob_star_does_not_cross_directories() {
 fn token_rule_compiles_to_token_limit() {
     let config = LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![Rule {
@@ -102,6 +106,7 @@ fn token_rule_compiles_to_token_limit() {
 fn rule_with_both_budgets_is_invalid() {
     let config = LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![Rule {
@@ -123,6 +128,7 @@ fn rule_with_both_budgets_is_invalid() {
 fn rule_without_budget_is_invalid() {
     let config = LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![Rule {
@@ -136,6 +142,39 @@ fn rule_without_budget_is_invalid() {
 
     assert!(matches!(err, ConfigError::InvalidLimit { .. }));
     assert!(err.to_string().contains("must set max_lines or max_tokens"));
+}
+
+#[test]
+fn default_token_limit_compiles() {
+    let config = LoqConfig {
+        default_max_lines: None,
+        default_max_tokens: Some(2000),
+        respect_gitignore: true,
+        exclude: vec![],
+        rules: vec![],
+        fix_guidance: None,
+    };
+    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+
+    assert_eq!(compiled.default_limit, Some(Limit::tokens(2000)));
+}
+
+#[test]
+fn both_default_budgets_are_invalid() {
+    let config = LoqConfig {
+        default_max_lines: Some(500),
+        default_max_tokens: Some(2000),
+        respect_gitignore: true,
+        exclude: vec![],
+        rules: vec![],
+        fix_guidance: None,
+    };
+    let err = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap_err();
+
+    assert!(matches!(err, ConfigError::InvalidLimit { .. }));
+    assert!(err
+        .to_string()
+        .contains("only one of default_max_lines or default_max_tokens"));
 }
 
 #[test]

--- a/crates/loq_core/src/decide.rs
+++ b/crates/loq_core/src/decide.rs
@@ -75,6 +75,7 @@ mod tests {
     fn rule_order_last_match_wins() {
         let config = LoqConfig {
             default_max_lines: Some(500),
+            default_max_tokens: None,
             respect_gitignore: true,
             exclude: vec![],
             rules: vec![
@@ -104,6 +105,7 @@ mod tests {
     fn default_fallback_when_no_rule() {
         let config = LoqConfig {
             default_max_lines: Some(123),
+            default_max_tokens: None,
             respect_gitignore: true,
             exclude: vec![],
             rules: vec![],
@@ -123,6 +125,7 @@ mod tests {
     fn skip_when_no_default_and_no_rule() {
         let config = LoqConfig {
             default_max_lines: None,
+            default_max_tokens: None,
             respect_gitignore: true,
             exclude: vec![],
             rules: vec![],
@@ -136,6 +139,7 @@ mod tests {
     fn multi_path_rule_matches_any() {
         let config = LoqConfig {
             default_max_lines: Some(500),
+            default_max_tokens: None,
             respect_gitignore: true,
             exclude: vec![],
             rules: vec![Rule {

--- a/crates/loq_core/src/parse.rs
+++ b/crates/loq_core/src/parse.rs
@@ -69,6 +69,7 @@ fn find_key_location(text: &str, key: &str) -> Option<(usize, usize)> {
 fn suggest_key(key: &str) -> Option<String> {
     let candidates = [
         "default_max_lines",
+        "default_max_tokens",
         "respect_gitignore",
         "exclude",
         "rules",
@@ -148,6 +149,14 @@ mod tests {
         assert_eq!(config.rules.len(), 1);
         assert_eq!(config.rules[0].max_lines, None);
         assert_eq!(config.rules[0].max_tokens, Some(8000));
+    }
+
+    #[test]
+    fn default_max_tokens_parsed() {
+        let text = "default_max_tokens = 2000\n";
+        let config = parse_config(Path::new("loq.toml"), text).unwrap();
+        assert_eq!(config.default_max_tokens, Some(2000));
+        assert_eq!(config.default_max_lines, None);
     }
 
     #[test]

--- a/crates/loq_fs/src/cache.rs
+++ b/crates/loq_fs/src/cache.rs
@@ -192,6 +192,7 @@ mod tests {
     fn make_config(default_max: Option<usize>) -> CompiledConfig {
         let config = LoqConfig {
             default_max_lines: default_max,
+            default_max_tokens: None,
             ..LoqConfig::default()
         };
         compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap()

--- a/crates/loq_fs/src/tests.rs
+++ b/crates/loq_fs/src/tests.rs
@@ -77,6 +77,7 @@ fn binary_and_unreadable_are_reported() {
     let temp = TempDir::new().unwrap();
     let config = loq_core::config::LoqConfig {
         default_max_lines: Some(1),
+        default_max_tokens: None,
         respect_gitignore: true,
         exclude: vec![],
         rules: vec![],


### PR DESCRIPTION
Stacked on #63. Last in the stack.

Mirrors the per-rule token budget at the top level: files matching no rule can now default to an approximate token budget instead of a line count. Previously a token budget was only reachable through an explicit rule, while lines got the zero-config default.

`default_max_lines` and `default_max_tokens` are mutually exclusive — like a rule, declaring both is a config error with a clear message. Documented in the README.