### PR TITLE
Remove dead check result state

### DIFF
--- a/crates/loq_cli/src/check/tests.rs
+++ b/crates/loq_cli/src/check/tests.rs
@@ -16,24 +16,19 @@ fn handle_fs_error_returns_error_status() {
 #[test]
 fn handle_check_output_default_mode_shows_missing_but_skips_other_warnings() {
     use loq_core::report::{FileOutcome, OutcomeKind};
-    use loq_core::ConfigOrigin;
     use termcolor::NoColor;
 
     let mut stdout = NoColor::new(Vec::new());
     let output = loq_fs::CheckOutput {
         outcomes: vec![
             FileOutcome {
-                path: "missing.txt".into(),
                 display_path: "missing.txt".into(),
                 match_key: "missing.txt".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Missing,
             },
             FileOutcome {
-                path: "skipped.bin".into(),
                 display_path: "skipped.bin".into(),
                 match_key: "skipped.bin".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Binary,
             },
         ],
@@ -53,16 +48,13 @@ fn handle_check_output_default_mode_shows_missing_but_skips_other_warnings() {
 #[test]
 fn handle_check_output_verbose_mode_shows_skip_warnings() {
     use loq_core::report::{FileOutcome, OutcomeKind};
-    use loq_core::ConfigOrigin;
     use termcolor::NoColor;
 
     let mut stdout = NoColor::new(Vec::new());
     let output = loq_fs::CheckOutput {
         outcomes: vec![FileOutcome {
-            path: "missing.txt".into(),
             display_path: "missing.txt".into(),
             match_key: "missing.txt".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Missing,
         }],
         walk_errors: vec![],
@@ -98,7 +90,6 @@ fn handle_check_output_with_walk_errors() {
 #[test]
 fn handle_check_output_json_format() {
     use loq_core::report::{FileOutcome, OutcomeKind};
-    use loq_core::ConfigOrigin;
     use loq_core::MatchBy;
     use loq_fs::walk::WalkError;
     use termcolor::NoColor;
@@ -107,10 +98,8 @@ fn handle_check_output_json_format() {
     let output = loq_fs::CheckOutput {
         outcomes: vec![
             FileOutcome {
-                path: "big.rs".into(),
                 display_path: "big.rs".into(),
                 match_key: "big.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: loq_core::Limit::lines(100),
                     actual: 150,
@@ -118,10 +107,8 @@ fn handle_check_output_json_format() {
                 },
             },
             FileOutcome {
-                path: "skipped.bin".into(),
                 display_path: "skipped.bin".into(),
                 match_key: "skipped.bin".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Binary,
             },
         ],

--- a/crates/loq_cli/src/line_violations.rs
+++ b/crates/loq_cli/src/line_violations.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use loq_core::config::{compile_config, ConfigOrigin, LoqConfig};
+use loq_core::config::{compile_config, LoqConfig};
 use loq_core::{FileOutcome, Limit, Metric, OutcomeKind};
 use loq_fs::{CheckConfig, CheckOptions};
 
@@ -41,12 +41,7 @@ pub(crate) fn scan_line_violations(
     config.rules.retain(|rule| {
         rule.limit.metric == Metric::Tokens || rule.paths.iter().any(|path| !is_exact_path(path))
     });
-    let compiled = compile_config(
-        ConfigOrigin::File(config_path.to_path_buf()),
-        root.clone(),
-        config,
-        Some(config_path),
-    )?;
+    let compiled = compile_config(root.clone(), config, Some(config_path))?;
     let options = CheckOptions {
         config: CheckConfig::Compiled(compiled),
         cwd: root,

--- a/crates/loq_cli/src/output/json.rs
+++ b/crates/loq_cli/src/output/json.rs
@@ -133,7 +133,6 @@ fn metric_value(value: usize, limit: Limit, metric: Metric) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loq_core::config::ConfigOrigin;
     use loq_core::report::{build_report, FileOutcome, OutcomeKind};
     use loq_fs::walk;
 
@@ -152,17 +151,13 @@ mod tests {
     fn all_outcomes_counted() {
         let outcomes = vec![
             FileOutcome {
-                path: "a.rs".into(),
                 display_path: "a.rs".into(),
                 match_key: "a.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::NoLimit,
             },
             FileOutcome {
-                path: "b.rs".into(),
                 display_path: "b.rs".into(),
                 match_key: "b.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Pass {
                     limit: loq_core::Limit::lines(100),
                     actual: 50,
@@ -170,10 +165,8 @@ mod tests {
                 },
             },
             FileOutcome {
-                path: "c.rs".into(),
                 display_path: "c.rs".into(),
                 match_key: "c.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: loq_core::Limit::lines(100),
                     actual: 150,
@@ -194,10 +187,8 @@ mod tests {
     #[test]
     fn missing_file_warning() {
         let outcomes = vec![FileOutcome {
-            path: "missing.rs".into(),
             display_path: "missing.rs".into(),
             match_key: "missing.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Missing,
         }];
 
@@ -213,10 +204,8 @@ mod tests {
     #[test]
     fn unreadable_file_warning() {
         let outcomes = vec![FileOutcome {
-            path: "locked.rs".into(),
             display_path: "locked.rs".into(),
             match_key: "locked.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Unreadable {
                 error: "permission denied".into(),
             },
@@ -234,10 +223,8 @@ mod tests {
     #[test]
     fn binary_file_warning() {
         let outcomes = vec![FileOutcome {
-            path: "image.png".into(),
             display_path: "image.png".into(),
             match_key: "image.png".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Binary,
         }];
 
@@ -253,10 +240,8 @@ mod tests {
     #[test]
     fn violation_with_rule_match() {
         let outcomes = vec![FileOutcome {
-            path: "big.rs".into(),
             display_path: "big.rs".into(),
             match_key: "big.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Violation {
                 limit: loq_core::Limit::lines(100),
                 actual: 200,
@@ -278,10 +263,8 @@ mod tests {
     #[test]
     fn token_violation_uses_token_fields() {
         let outcomes = vec![FileOutcome {
-            path: "prompt.md".into(),
             display_path: "prompt.md".into(),
             match_key: "prompt.md".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Violation {
                 limit: loq_core::Limit::tokens(4),
                 actual: 5,
@@ -305,10 +288,8 @@ mod tests {
     #[test]
     fn violation_with_default_match() {
         let outcomes = vec![FileOutcome {
-            path: "big.rs".into(),
             display_path: "big.rs".into(),
             match_key: "big.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Violation {
                 limit: loq_core::Limit::lines(100),
                 actual: 200,
@@ -347,10 +328,8 @@ mod tests {
     #[test]
     fn fix_guidance_included_with_violations() {
         let outcomes = vec![FileOutcome {
-            path: "big.rs".into(),
             display_path: "big.rs".into(),
             match_key: "big.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Violation {
                 limit: loq_core::Limit::lines(100),
                 actual: 200,
@@ -367,10 +346,8 @@ mod tests {
     #[test]
     fn fix_guidance_excluded_without_violations() {
         let outcomes = vec![FileOutcome {
-            path: "small.rs".into(),
             display_path: "small.rs".into(),
             match_key: "small.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Pass {
                 limit: loq_core::Limit::lines(100),
                 actual: 50,
@@ -388,10 +365,8 @@ mod tests {
     fn violations_sorted_by_path() {
         let outcomes = vec![
             FileOutcome {
-                path: "z.rs".into(),
                 display_path: "z.rs".into(),
                 match_key: "z.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: loq_core::Limit::lines(100),
                     actual: 200,
@@ -399,10 +374,8 @@ mod tests {
                 },
             },
             FileOutcome {
-                path: "a.rs".into(),
                 display_path: "a.rs".into(),
                 match_key: "a.rs".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: loq_core::Limit::lines(100),
                     actual: 200,

--- a/crates/loq_cli/src/output/tests.rs
+++ b/crates/loq_cli/src/output/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use loq_core::report::{Finding, FindingKind, SkipReason, Summary};
-use loq_core::{ConfigOrigin, MatchBy};
+use loq_core::MatchBy;
 use termcolor::NoColor;
 
 fn output_string<F>(f: F) -> String
@@ -76,11 +76,9 @@ fn write_block_single_line() {
 fn write_finding_violation() {
     let finding = Finding {
         path: "src/main.rs".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::Violation {
             limit: loq_core::Limit::lines(100),
             actual: 150,
-            over_by: 50,
             matched_by: MatchBy::Default,
         },
     };
@@ -96,11 +94,9 @@ fn write_finding_violation() {
 fn write_finding_token_violation_marks_approximate_unit() {
     let finding = Finding {
         path: "prompts/build.md".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::Violation {
             limit: loq_core::Limit::tokens(4),
             actual: 5,
-            over_by: 1,
             matched_by: MatchBy::Rule {
                 pattern: "prompts/**/*.md".into(),
             },
@@ -118,11 +114,9 @@ fn write_finding_token_violation_marks_approximate_unit() {
 fn write_finding_token_violation_verbose_shows_token_rule() {
     let finding = Finding {
         path: "prompts/build.md".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::Violation {
             limit: loq_core::Limit::tokens(4),
             actual: 5,
-            over_by: 1,
             matched_by: MatchBy::Rule {
                 pattern: "prompts/**/*.md".into(),
             },
@@ -139,11 +133,9 @@ fn write_finding_token_violation_verbose_shows_token_rule() {
 fn write_finding_violation_verbose_default_match() {
     let finding = Finding {
         path: "src/lib.rs".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::Violation {
             limit: loq_core::Limit::lines(100),
             actual: 200,
-            over_by: 100,
             matched_by: MatchBy::Default,
         },
     };
@@ -156,11 +148,9 @@ fn write_finding_violation_verbose_default_match() {
 fn write_finding_violation_verbose_rule_match() {
     let finding = Finding {
         path: "src/lib.rs".into(),
-        config_source: ConfigOrigin::File(std::path::PathBuf::from("/project/loq.toml")),
         kind: FindingKind::Violation {
             limit: loq_core::Limit::lines(50),
             actual: 75,
-            over_by: 25,
             matched_by: MatchBy::Rule {
                 pattern: "**/*.rs".into(),
             },
@@ -175,7 +165,6 @@ fn write_finding_violation_verbose_rule_match() {
 fn write_finding_skip_binary() {
     let finding = Finding {
         path: "image.png".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::SkipWarning {
             reason: SkipReason::Binary,
         },
@@ -189,7 +178,6 @@ fn write_finding_skip_binary() {
 fn write_finding_skip_missing() {
     let finding = Finding {
         path: "missing.txt".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::SkipWarning {
             reason: SkipReason::Missing,
         },
@@ -202,7 +190,6 @@ fn write_finding_skip_missing() {
 fn write_finding_skip_unreadable() {
     let finding = Finding {
         path: "locked.txt".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::SkipWarning {
             reason: SkipReason::Unreadable("permission denied".into()),
         },
@@ -216,11 +203,9 @@ fn write_finding_skip_unreadable() {
 fn write_finding_path_without_directory() {
     let finding = Finding {
         path: "file.txt".into(),
-        config_source: ConfigOrigin::BuiltIn,
         kind: FindingKind::Violation {
             limit: loq_core::Limit::lines(10),
             actual: 20,
-            over_by: 10,
             matched_by: MatchBy::Default,
         },
     };

--- a/crates/loq_core/src/config.rs
+++ b/crates/loq_core/src/config.rs
@@ -51,20 +51,9 @@ impl Default for LoqConfig {
     }
 }
 
-/// Where a configuration came from.
-#[derive(Debug, Clone)]
-pub enum ConfigOrigin {
-    /// Using built-in defaults (no config file found).
-    BuiltIn,
-    /// Loaded from a specific file path.
-    File(PathBuf),
-}
-
 /// Configuration with compiled glob matchers, ready for use.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CompiledConfig {
-    /// Where this config came from.
-    pub origin: ConfigOrigin,
     /// Root directory for relative path matching.
     pub root_dir: PathBuf,
     /// Default budget for files not matching any rule.
@@ -225,7 +214,6 @@ fn format_unknown_key_error(
 /// Takes a `LoqConfig` and compiles all glob patterns into matchers.
 /// The `root_dir` is used for relative path matching during checks.
 pub fn compile_config(
-    origin: ConfigOrigin,
     root_dir: PathBuf,
     config: LoqConfig,
     source_path: Option<&Path>,
@@ -248,7 +236,6 @@ pub fn compile_config(
     }
 
     Ok(CompiledConfig {
-        origin,
         root_dir,
         default_limit: config.default_limit,
         respect_gitignore: config.respect_gitignore,

--- a/crates/loq_core/src/config/tests.rs
+++ b/crates/loq_core/src/config/tests.rs
@@ -22,7 +22,7 @@ fn invalid_glob_reports_error() {
         }],
         fix_guidance: None,
     };
-    let err = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap_err();
+    let err = compile_config(PathBuf::from("."), config, None).unwrap_err();
     assert!(matches!(err, ConfigError::Glob { .. }));
 }
 
@@ -35,7 +35,7 @@ fn glob_error_display_is_stable() {
         rules: vec![],
         fix_guidance: None,
     };
-    let err = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap_err();
+    let err = compile_config(PathBuf::from("."), config, None).unwrap_err();
     assert!(err.to_string().contains("invalid glob"));
 }
 
@@ -51,7 +51,7 @@ fn glob_star_does_not_cross_directories() {
         }],
         fix_guidance: None,
     };
-    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+    let compiled = compile_config(PathBuf::from("."), config, None).unwrap();
     let rule = &compiled.rules()[0];
 
     assert!(rule.matches("src/lib.rs").is_some());
@@ -70,7 +70,7 @@ fn token_rule_compiles_to_token_limit() {
         }],
         fix_guidance: None,
     };
-    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+    let compiled = compile_config(PathBuf::from("."), config, None).unwrap();
 
     assert_eq!(compiled.rules()[0].limit, Limit::tokens(8000));
 }
@@ -84,7 +84,7 @@ fn default_token_limit_compiles() {
         rules: vec![],
         fix_guidance: None,
     };
-    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+    let compiled = compile_config(PathBuf::from("."), config, None).unwrap();
 
     assert_eq!(compiled.default_limit, Some(Limit::tokens(2000)));
 }

--- a/crates/loq_core/src/decide.rs
+++ b/crates/loq_core/src/decide.rs
@@ -64,11 +64,11 @@ pub fn decide(config: &CompiledConfig, path: &str) -> Decision {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{compile_config, ConfigOrigin, LoqConfig, Rule};
+    use crate::config::{compile_config, LoqConfig, Rule};
     use std::path::PathBuf;
 
     fn compiled(config: LoqConfig) -> CompiledConfig {
-        compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap()
+        compile_config(PathBuf::from("."), config, None).unwrap()
     }
 
     #[test]

--- a/crates/loq_core/src/lib.rs
+++ b/crates/loq_core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod limit;
 pub mod parse;
 pub mod report;
 
-pub use config::{CompiledConfig, ConfigError, ConfigOrigin, LoqConfig, PatternList, Rule};
+pub use config::{CompiledConfig, ConfigError, LoqConfig, PatternList, Rule};
 pub use decide::{Decision, MatchBy};
 pub use limit::{Limit, Metric};
 pub use parse::parse_config;

--- a/crates/loq_core/src/report.rs
+++ b/crates/loq_core/src/report.rs
@@ -2,27 +2,22 @@
 //!
 //! Collects file check outcomes and generates structured reports.
 
-use crate::config::ConfigOrigin;
 use crate::decide::MatchBy;
 use crate::Limit;
 
 /// The result of checking a single file.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FileOutcome {
-    /// Absolute path to the file.
-    pub path: std::path::PathBuf,
     /// Path relative to working directory for display.
     pub display_path: String,
     /// Path relative to config root for rule matching and managed exact-path rules.
     pub match_key: String,
-    /// Which config was used for this file.
-    pub config_source: ConfigOrigin,
     /// What happened when checking the file.
     pub kind: OutcomeKind,
 }
 
 /// What happened when checking a file.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum OutcomeKind {
     /// No limit configured for this file.
     NoLimit,
@@ -56,7 +51,7 @@ pub enum OutcomeKind {
 }
 
 /// Why a file was skipped (for warnings).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum SkipReason {
     /// Binary file (contains null bytes).
     Binary,
@@ -67,7 +62,7 @@ pub enum SkipReason {
 }
 
 /// A reportable finding (violation or skip warning).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum FindingKind {
     /// File exceeded its configured budget.
     Violation {
@@ -75,8 +70,6 @@ pub enum FindingKind {
         limit: Limit,
         /// Actual measured value.
         actual: usize,
-        /// Amount over the limit.
-        over_by: usize,
         /// How the limit was determined.
         matched_by: MatchBy,
     },
@@ -88,18 +81,16 @@ pub enum FindingKind {
 }
 
 /// A single finding to report.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Finding {
     /// Display path for the file.
     pub path: String,
-    /// Which config was used.
-    pub config_source: ConfigOrigin,
     /// What kind of finding this is.
     pub kind: FindingKind,
 }
 
 /// Summary statistics for a check run.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct Summary {
     /// Total files processed.
     pub total: usize,
@@ -112,7 +103,7 @@ pub struct Summary {
 }
 
 /// The complete report from a check run.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Report {
     /// All findings (skip warnings first, then violations by overage).
     pub findings: Vec<Finding>,
@@ -189,7 +180,6 @@ pub fn build_report(outcomes: &[FileOutcome], fix_guidance: Option<String>) -> R
 fn push_skip_warning(findings: &mut Vec<Finding>, outcome: &FileOutcome, reason: SkipReason) {
     findings.push(Finding {
         path: outcome.display_path.clone(),
-        config_source: outcome.config_source.clone(),
         kind: FindingKind::SkipWarning { reason },
     });
 }
@@ -201,14 +191,11 @@ fn push_violation(
     actual: usize,
     matched_by: MatchBy,
 ) {
-    let over_by = actual.saturating_sub(limit.max);
     findings.push(Finding {
         path: outcome.display_path.clone(),
-        config_source: outcome.config_source.clone(),
         kind: FindingKind::Violation {
             limit,
             actual,
-            over_by,
             matched_by,
         },
     });
@@ -225,12 +212,18 @@ pub fn sort_findings(findings: &mut [Finding]) {
         match (&a.kind, &b.kind) {
             (
                 FindingKind::Violation {
-                    over_by: a_over, ..
+                    limit: a_limit,
+                    actual: a_actual,
+                    ..
                 },
                 FindingKind::Violation {
-                    over_by: b_over, ..
+                    limit: b_limit,
+                    actual: b_actual,
+                    ..
                 },
-            ) => a_over.cmp(b_over).then_with(|| a.path.cmp(&b.path)),
+            ) => (a_actual - a_limit.max)
+                .cmp(&(b_actual - b_limit.max))
+                .then_with(|| a.path.cmp(&b.path)),
             _ => a.path.cmp(&b.path),
         }
     });
@@ -246,17 +239,14 @@ const fn finding_rank(kind: &FindingKind) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ConfigOrigin;
     use crate::Limit;
 
     #[test]
     fn summary_counts_each_file_once() {
         let outcomes = vec![
             FileOutcome {
-                path: "a".into(),
                 display_path: "a".into(),
                 match_key: "a".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Pass {
                     limit: Limit::lines(10),
                     actual: 5,
@@ -264,10 +254,8 @@ mod tests {
                 },
             },
             FileOutcome {
-                path: "b".into(),
                 display_path: "b".into(),
                 match_key: "b".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: Limit::lines(10),
                     actual: 20,
@@ -275,10 +263,8 @@ mod tests {
                 },
             },
             FileOutcome {
-                path: "c".into(),
                 display_path: "c".into(),
                 match_key: "c".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Violation {
                     limit: Limit::lines(10),
                     actual: 12,
@@ -286,24 +272,18 @@ mod tests {
                 },
             },
             FileOutcome {
-                path: "d".into(),
                 display_path: "d".into(),
                 match_key: "d".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Missing,
             },
             FileOutcome {
-                path: "e".into(),
                 display_path: "e".into(),
                 match_key: "e".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Binary,
             },
             FileOutcome {
-                path: "f".into(),
                 display_path: "f".into(),
                 match_key: "f".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: OutcomeKind::Unreadable {
                     error: "denied".into(),
                 },
@@ -321,27 +301,22 @@ mod tests {
         let mut findings = vec![
             Finding {
                 path: "b".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: FindingKind::Violation {
                     limit: Limit::lines(10),
                     actual: 12,
-                    over_by: 2,
                     matched_by: MatchBy::Default,
                 },
             },
             Finding {
                 path: "a".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: FindingKind::Violation {
                     limit: Limit::lines(10),
                     actual: 20,
-                    over_by: 10,
                     matched_by: MatchBy::Default,
                 },
             },
             Finding {
                 path: "c".into(),
-                config_source: ConfigOrigin::BuiltIn,
                 kind: FindingKind::SkipWarning {
                     reason: SkipReason::Missing,
                 },
@@ -357,10 +332,8 @@ mod tests {
     #[test]
     fn nolimit_is_skipped() {
         let outcomes = vec![FileOutcome {
-            path: "nolimit.js".into(),
             display_path: "nolimit.js".into(),
             match_key: "nolimit.js".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::NoLimit,
         }];
         let report = build_report(&outcomes, None);
@@ -375,10 +348,8 @@ mod tests {
     #[test]
     fn fix_guidance_included_when_violations_exist() {
         let outcomes = vec![FileOutcome {
-            path: "big.rs".into(),
             display_path: "big.rs".into(),
             match_key: "big.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Violation {
                 limit: Limit::lines(100),
                 actual: 150,
@@ -398,10 +369,8 @@ mod tests {
     #[test]
     fn fix_guidance_excluded_when_no_violations() {
         let outcomes = vec![FileOutcome {
-            path: "small.rs".into(),
             display_path: "small.rs".into(),
             match_key: "small.rs".into(),
-            config_source: ConfigOrigin::BuiltIn,
             kind: OutcomeKind::Pass {
                 limit: Limit::lines(100),
                 actual: 50,

--- a/crates/loq_fs/src/cache.rs
+++ b/crates/loq_fs/src/cache.rs
@@ -185,7 +185,7 @@ pub fn hash_config(config: &CompiledConfig) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loq_core::config::{compile_config, ConfigOrigin, LoqConfig};
+    use loq_core::config::{compile_config, LoqConfig};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -194,7 +194,7 @@ mod tests {
             default_limit: default_max.map(loq_core::Limit::lines),
             ..LoqConfig::default()
         };
-        compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap()
+        compile_config(PathBuf::from("."), config, None).unwrap()
     }
 
     #[test]

--- a/crates/loq_fs/src/lib.rs
+++ b/crates/loq_fs/src/lib.rs
@@ -18,7 +18,7 @@ pub use path_identity::PathIdentity;
 
 use std::path::{Path, PathBuf};
 
-use loq_core::config::{compile_config, CompiledConfig, ConfigOrigin, LoqConfig};
+use loq_core::config::{compile_config, CompiledConfig, LoqConfig};
 use loq_core::decide::{decide, Decision};
 use loq_core::report::{FileOutcome, OutcomeKind};
 use rayon::prelude::*;
@@ -87,12 +87,7 @@ fn load_config_from_path(path: &Path, fallback_cwd: &Path) -> Result<CompiledCon
         error,
     })?;
     let config = loq_core::parse_config(path, &text)?;
-    let compiled = compile_config(
-        ConfigOrigin::File(path.to_path_buf()),
-        root_dir,
-        config,
-        Some(path),
-    )?;
+    let compiled = compile_config(root_dir, config, Some(path))?;
     Ok(compiled)
 }
 
@@ -115,7 +110,7 @@ pub fn run_check(paths: Vec<PathBuf>, options: CheckOptions) -> Result<CheckOutp
                     .cwd
                     .canonicalize()
                     .unwrap_or_else(|_| options.cwd.clone());
-                compile_config(ConfigOrigin::BuiltIn, root_dir, config, None)?
+                compile_config(root_dir, config, None)?
             }
         }
     };
@@ -179,24 +174,18 @@ fn check_file(
     inspector: &Inspector,
 ) -> FileOutcome {
     let identity = PathIdentity::new(path, cwd_abs, &compiled.root_dir);
-    let config_source = compiled.origin.clone();
-
-    let make_outcome = |kind| FileOutcome {
-        path: identity.absolute.clone(),
-        display_path: identity.display.clone(),
-        match_key: identity.match_key.clone(),
-        config_source: config_source.clone(),
-        kind,
-    };
-
     let kind = match decide(compiled, &identity.match_key) {
         Decision::SkipNoLimit => OutcomeKind::NoLimit,
         Decision::Check { limit, matched_by } => {
-            inspector.inspect(path, &identity.cache_key, limit, matched_by)
+            inspector.inspect(path, &identity.match_key, limit, matched_by)
         }
     };
 
-    make_outcome(kind)
+    FileOutcome {
+        display_path: identity.display,
+        match_key: identity.match_key,
+        kind,
+    }
 }
 
 #[cfg(test)]

--- a/crates/loq_fs/src/path_identity.rs
+++ b/crates/loq_fs/src/path_identity.rs
@@ -1,21 +1,18 @@
 //! Path identity for checked files.
 //!
-//! Centralizes the path forms used by loq: absolute filesystem path,
-//! cwd-relative display path, config-root-relative match key, and cache key.
+//! Centralizes the cwd-relative display path and config-root-relative match key.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 
 /// The path forms loq needs for one checked file.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PathIdentity {
-    /// Absolute path to the file, or cwd joined with the input path for missing files.
-    pub absolute: PathBuf,
     /// Path relative to the working directory for output.
     pub display: String,
     /// Path relative to the config root for rule matching and managed exact-path rules.
     pub match_key: String,
-    /// Cache key for file inspection results.
-    pub cache_key: String,
 }
 
 impl PathIdentity {
@@ -27,14 +24,8 @@ impl PathIdentity {
         let absolute = path.canonicalize().unwrap_or_else(|_| cwd.join(path));
         let display = display_key(&absolute, cwd);
         let match_key = relative_key(&absolute, root);
-        let cache_key = match_key.clone();
 
-        Self {
-            absolute,
-            display,
-            match_key,
-            cache_key,
-        }
+        Self { display, match_key }
     }
 }
 
@@ -135,8 +126,6 @@ mod tests {
 
         assert_eq!(identity.display, "../src/app.rs");
         assert_eq!(identity.match_key, "src/app.rs");
-        assert_eq!(identity.cache_key, identity.match_key);
-        assert_eq!(identity.absolute, file.canonicalize().unwrap());
     }
 
     #[test]
@@ -147,7 +136,6 @@ mod tests {
 
         let identity = PathIdentity::new(missing, &root, &root);
 
-        assert_eq!(identity.absolute, root.join("missing.rs"));
         assert_eq!(identity.display, "missing.rs");
         assert_eq!(identity.match_key, "missing.rs");
     }

--- a/crates/loq_fs/src/tests.rs
+++ b/crates/loq_fs/src/tests.rs
@@ -82,13 +82,8 @@ fn binary_and_unreadable_are_reported() {
         rules: vec![],
         fix_guidance: None,
     };
-    let compiled = loq_core::config::compile_config(
-        loq_core::config::ConfigOrigin::BuiltIn,
-        temp.path().to_path_buf(),
-        config,
-        None,
-    )
-    .unwrap();
+    let compiled =
+        loq_core::config::compile_config(temp.path().to_path_buf(), config, None).unwrap();
     let inspector = inspection::Inspector::new(cache::Cache::empty());
 
     let binary = temp.path().join("binary.txt");

--- a/crates/loq_fs/src/walk/tests.rs
+++ b/crates/loq_fs/src/walk/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use loq_core::config::{compile_config, ConfigOrigin, LoqConfig};
+use loq_core::config::{compile_config, LoqConfig};
 use tempfile::TempDir;
 
 #[cfg(unix)]
@@ -22,7 +22,7 @@ fn empty_exclude() -> loq_core::PatternList {
         exclude: vec![],
         ..LoqConfig::default()
     };
-    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+    let compiled = compile_config(PathBuf::from("."), config, None).unwrap();
     compiled.exclude_patterns().clone()
 }
 
@@ -31,7 +31,7 @@ fn exclude_pattern(pattern: &str) -> loq_core::PatternList {
         exclude: vec![pattern.to_string()],
         ..LoqConfig::default()
     };
-    let compiled = compile_config(ConfigOrigin::BuiltIn, PathBuf::from("."), config, None).unwrap();
+    let compiled = compile_config(PathBuf::from("."), config, None).unwrap();
     compiled.exclude_patterns().clone()
 }
 


### PR DESCRIPTION
Removes unused config provenance, absolute path, duplicate cache key, and stored overage fields from the check and report models. These values were copied through the crates but never rendered or consumed.

Checks now use the match key directly for cache and rule lookup, while report sorting derives overage from the existing measurement and limit. This also removes unused `Clone` implementations from the affected types.