### PR TITLE
Encode valid limit changes

### DIFF
--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -11,13 +11,13 @@ use crate::config_edit::{config_path_and_root, line_threshold, load_doc_or_defau
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::line_violations::scan_line_violations;
 use crate::output::{
-    change_style, max_formatted_width, plural, print_error, write_change_row, write_ok_line,
-    ChangeKind, ChangeRow, ChangeStyle,
+    change_style, change_width, plural, print_error, write_change, write_ok_line, Change,
+    ChangeStyle,
 };
 use crate::ExitStatus;
 
 struct BaselineReport {
-    changes: Vec<ChangeRow>,
+    changes: Vec<Change>,
 }
 
 pub fn run_baseline<W1: WriteColor, W2: WriteColor>(
@@ -69,20 +69,17 @@ fn apply_baseline_changes(
         if let Some(&actual) = violations.get(path) {
             if actual != limit.max_lines {
                 exact_limits::update_limit(doc, limit, actual);
-                changes.push(ChangeRow {
+                changes.push(Change::Updated {
                     path: path.to_string(),
-                    from: Some(limit.max_lines),
-                    to: Some(actual),
-                    kind: ChangeKind::Updated,
+                    from: limit.max_lines,
+                    to: actual,
                 });
             }
         } else {
             limits_to_remove.push(limit);
-            changes.push(ChangeRow {
+            changes.push(Change::Removed {
                 path: path.to_string(),
-                from: Some(limit.max_lines),
-                to: None,
-                kind: ChangeKind::Removed,
+                from: limit.max_lines,
             });
         }
     }
@@ -97,11 +94,9 @@ fn apply_baseline_changes(
 
     for (path, &actual) in new_violations {
         exact_limits::set_limit(doc, existing_rules, path, actual);
-        changes.push(ChangeRow {
+        changes.push(Change::Added {
             path: (*path).clone(),
-            from: None,
-            to: Some(actual),
-            kind: ChangeKind::Added,
+            to: actual,
         });
     }
 
@@ -116,12 +111,8 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &BaselineReport) -> std::
     let style = change_style();
 
     let mut changes: Vec<_> = report.changes.iter().collect();
-    changes.sort_by_key(|change| (change_sort_value(change), change.path.as_str()));
-    let width = max_formatted_width(
-        changes
-            .iter()
-            .flat_map(|change| change.from.into_iter().chain(change.to)),
-    );
+    changes.sort_by_key(|change| (change.sort_value(), change.path()));
+    let width = change_width(&changes);
     let counts = write_change_lines(writer, &changes, width, &style)?;
 
     if counts.added > 0 || counts.updated > 0 {
@@ -143,13 +134,6 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &BaselineReport) -> std::
     Ok(())
 }
 
-fn change_sort_value(change: &ChangeRow) -> usize {
-    match change.kind {
-        ChangeKind::Removed => change.from.unwrap_or(0),
-        _ => change.to.or(change.from).unwrap_or(0),
-    }
-}
-
 struct ChangeCounts {
     added: usize,
     updated: usize,
@@ -158,7 +142,7 @@ struct ChangeCounts {
 
 fn write_change_lines<W: WriteColor>(
     writer: &mut W,
-    changes: &[&ChangeRow],
+    changes: &[&Change],
     width: usize,
     style: &ChangeStyle,
 ) -> std::io::Result<ChangeCounts> {
@@ -169,23 +153,14 @@ fn write_change_lines<W: WriteColor>(
     };
 
     for change in changes {
-        match change.kind {
-            ChangeKind::Added => counts.added += 1,
-            ChangeKind::Updated => counts.updated += 1,
-            ChangeKind::Removed => counts.removed += 1,
-            ChangeKind::Adjusted => {}
+        match change {
+            Change::Added { .. } => counts.added += 1,
+            Change::Updated { .. } => counts.updated += 1,
+            Change::Removed { .. } => counts.removed += 1,
+            Change::Adjusted { .. } => {}
         }
 
-        let symbol = change.kind.symbol();
-        write_change_row(
-            writer,
-            style,
-            width,
-            symbol,
-            change.from,
-            change.to,
-            &change.path,
-        )?;
+        write_change(writer, style, width, change)?;
     }
 
     Ok(counts)
@@ -216,23 +191,18 @@ mod tests {
     fn write_report_sorts_by_limit_and_summarizes() {
         let report = BaselineReport {
             changes: vec![
-                ChangeRow {
+                Change::Updated {
                     path: "b.rs".into(),
-                    from: Some(200),
-                    to: Some(150),
-                    kind: ChangeKind::Updated,
+                    from: 200,
+                    to: 150,
                 },
-                ChangeRow {
+                Change::Added {
                     path: "a.rs".into(),
-                    from: None,
-                    to: Some(120),
-                    kind: ChangeKind::Added,
+                    to: 120,
                 },
-                ChangeRow {
+                Change::Removed {
                     path: "c.rs".into(),
-                    from: Some(300),
-                    to: None,
-                    kind: ChangeKind::Removed,
+                    from: 300,
                 },
             ],
         };
@@ -256,11 +226,9 @@ mod tests {
     #[test]
     fn write_report_handles_removed_only() {
         let report = BaselineReport {
-            changes: vec![ChangeRow {
+            changes: vec![Change::Removed {
                 path: "src/old.rs".into(),
-                from: Some(10),
-                to: None,
-                kind: ChangeKind::Removed,
+                from: 10,
             }],
         };
 

--- a/crates/loq_cli/src/baseline.rs
+++ b/crates/loq_cli/src/baseline.rs
@@ -146,20 +146,22 @@ fn write_change_lines<W: WriteColor>(
     width: usize,
     style: &ChangeStyle,
 ) -> std::io::Result<ChangeCounts> {
-    let mut counts = ChangeCounts {
-        added: 0,
-        updated: 0,
-        removed: 0,
+    let counts = ChangeCounts {
+        added: changes
+            .iter()
+            .filter(|change| matches!(change, Change::Added { .. }))
+            .count(),
+        updated: changes
+            .iter()
+            .filter(|change| matches!(change, Change::Updated { .. }))
+            .count(),
+        removed: changes
+            .iter()
+            .filter(|change| matches!(change, Change::Removed { .. }))
+            .count(),
     };
 
     for change in changes {
-        match change {
-            Change::Added { .. } => counts.added += 1,
-            Change::Updated { .. } => counts.updated += 1,
-            Change::Removed { .. } => counts.removed += 1,
-            Change::Adjusted { .. } => {}
-        }
-
         write_change(writer, style, width, change)?;
     }
 

--- a/crates/loq_cli/src/output/mod.rs
+++ b/crates/loq_cli/src/output/mod.rs
@@ -39,30 +39,55 @@ pub struct ChangeStyle {
     pub dimmed: ColorSpec,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ChangeKind {
-    Added,
-    Updated,
-    Removed,
-    Adjusted,
+pub enum Change {
+    Added {
+        path: String,
+        to: usize,
+    },
+    Updated {
+        path: String,
+        from: usize,
+        to: usize,
+    },
+    Removed {
+        path: String,
+        from: usize,
+    },
+    Adjusted {
+        path: String,
+        from: usize,
+        to: usize,
+    },
 }
 
-impl ChangeKind {
-    pub const fn symbol(self) -> Option<&'static str> {
+impl Change {
+    #[must_use]
+    pub fn path(&self) -> &str {
         match self {
-            Self::Added => Some("+"),
-            Self::Updated => Some("~"),
-            Self::Removed => Some("-"),
-            Self::Adjusted => None,
+            Self::Added { path, .. }
+            | Self::Updated { path, .. }
+            | Self::Removed { path, .. }
+            | Self::Adjusted { path, .. } => path,
         }
     }
-}
 
-pub struct ChangeRow {
-    pub path: String,
-    pub from: Option<usize>,
-    pub to: Option<usize>,
-    pub kind: ChangeKind,
+    #[must_use]
+    pub const fn sort_value(&self) -> usize {
+        match self {
+            Self::Added { to, .. } | Self::Updated { to, .. } | Self::Adjusted { to, .. } => *to,
+            Self::Removed { from, .. } => *from,
+        }
+    }
+
+    #[must_use]
+    pub const fn previous(&self) -> Option<usize> {
+        match self {
+            Self::Added { .. } => None,
+            Self::Updated { from, .. }
+            | Self::Removed { from, .. }
+            | Self::Adjusted { from, .. } => Some(*from),
+        }
+    }
 }
 
 /// Builds color specs for change reports.
@@ -84,14 +109,25 @@ pub fn change_style() -> ChangeStyle {
     }
 }
 
-/// Computes a display width for formatted numbers (minimum 6).
-pub fn max_formatted_width<I>(values: I) -> usize
-where
-    I: IntoIterator<Item = usize>,
-{
-    values
-        .into_iter()
-        .fold(6, |current, value| current.max(format_number(value).len()))
+/// Computes a display width for change values (minimum 6).
+pub fn change_width(changes: &[&Change]) -> usize {
+    let mut width = 6;
+    for change in changes {
+        match change {
+            Change::Added { to, .. } => {
+                width = width.max(format_number(*to).len());
+            }
+            Change::Updated { from, to, .. } | Change::Adjusted { from, to, .. } => {
+                width = width
+                    .max(format_number(*from).len())
+                    .max(format_number(*to).len());
+            }
+            Change::Removed { from, .. } => {
+                width = width.max(format_number(*from).len());
+            }
+        }
+    }
+    width
 }
 
 /// Returns the plural suffix (`""` or `"s"`) for `count`.
@@ -119,15 +155,19 @@ pub fn write_ok_line<W: WriteColor>(
     writeln!(writer)
 }
 
-pub fn write_change_row<W: WriteColor>(
+pub fn write_change<W: WriteColor>(
     writer: &mut W,
     style: &ChangeStyle,
     width: usize,
-    symbol: Option<&str>,
-    from: Option<usize>,
-    to: Option<usize>,
-    path: &str,
+    change: &Change,
 ) -> io::Result<()> {
+    let (symbol, from, to, path) = match change {
+        Change::Added { path, to } => (Some("+"), None, Some(*to), path),
+        Change::Updated { path, from, to } => (Some("~"), Some(*from), Some(*to), path),
+        Change::Removed { path, from } => (Some("-"), Some(*from), None, path),
+        Change::Adjusted { path, from, to } => (None, Some(*from), Some(*to), path),
+    };
+
     if let Some(symbol) = symbol {
         writer.set_color(&style.dimmed)?;
         write!(writer, "{symbol} ")?;

--- a/crates/loq_cli/src/output/mod.rs
+++ b/crates/loq_cli/src/output/mod.rs
@@ -80,12 +80,32 @@ impl Change {
     }
 
     #[must_use]
-    pub const fn previous(&self) -> Option<usize> {
+    pub const fn from(&self) -> Option<usize> {
         match self {
             Self::Added { .. } => None,
             Self::Updated { from, .. }
             | Self::Removed { from, .. }
             | Self::Adjusted { from, .. } => Some(*from),
+        }
+    }
+
+    #[must_use]
+    pub const fn to(&self) -> Option<usize> {
+        match self {
+            Self::Removed { .. } => None,
+            Self::Added { to, .. } | Self::Updated { to, .. } | Self::Adjusted { to, .. } => {
+                Some(*to)
+            }
+        }
+    }
+
+    #[must_use]
+    pub const fn symbol(&self) -> Option<&'static str> {
+        match self {
+            Self::Added { .. } => Some("+"),
+            Self::Updated { .. } => Some("~"),
+            Self::Removed { .. } => Some("-"),
+            Self::Adjusted { .. } => None,
         }
     }
 }
@@ -111,23 +131,10 @@ pub fn change_style() -> ChangeStyle {
 
 /// Computes a display width for change values (minimum 6).
 pub fn change_width(changes: &[&Change]) -> usize {
-    let mut width = 6;
-    for change in changes {
-        match change {
-            Change::Added { to, .. } => {
-                width = width.max(format_number(*to).len());
-            }
-            Change::Updated { from, to, .. } | Change::Adjusted { from, to, .. } => {
-                width = width
-                    .max(format_number(*from).len())
-                    .max(format_number(*to).len());
-            }
-            Change::Removed { from, .. } => {
-                width = width.max(format_number(*from).len());
-            }
-        }
-    }
-    width
+    changes
+        .iter()
+        .flat_map(|change| change.from().into_iter().chain(change.to()))
+        .fold(6, |width, value| width.max(format_number(value).len()))
 }
 
 /// Returns the plural suffix (`""` or `"s"`) for `count`.
@@ -161,14 +168,10 @@ pub fn write_change<W: WriteColor>(
     width: usize,
     change: &Change,
 ) -> io::Result<()> {
-    let (symbol, from, to, path) = match change {
-        Change::Added { path, to } => (Some("+"), None, Some(*to), path),
-        Change::Updated { path, from, to } => (Some("~"), Some(*from), Some(*to), path),
-        Change::Removed { path, from } => (Some("-"), Some(*from), None, path),
-        Change::Adjusted { path, from, to } => (None, Some(*from), Some(*to), path),
-    };
+    let from = change.from();
+    let to = change.to();
 
-    if let Some(symbol) = symbol {
+    if let Some(symbol) = change.symbol() {
         writer.set_color(&style.dimmed)?;
         write!(writer, "{symbol} ")?;
         writer.reset()?;
@@ -195,7 +198,7 @@ pub fn write_change<W: WriteColor>(
     write!(writer, "{to_str:<width$}")?;
     writer.reset()?;
     write!(writer, " ")?;
-    write_path(writer, path)?;
+    write_path(writer, change.path())?;
     writeln!(writer)?;
 
     Ok(())

--- a/crates/loq_cli/src/relax.rs
+++ b/crates/loq_cli/src/relax.rs
@@ -107,7 +107,7 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &RelaxReport) -> std::io:
     let style = change_style();
 
     let mut changes: Vec<_> = report.changes.iter().collect();
-    changes.sort_by_key(|change| (change.sort_value(), change.previous(), change.path()));
+    changes.sort_by_key(|change| (change.sort_value(), change.from(), change.path()));
     let width = change_width(&changes);
 
     for change in changes {

--- a/crates/loq_cli/src/relax.rs
+++ b/crates/loq_cli/src/relax.rs
@@ -12,13 +12,12 @@ use crate::config_edit::{config_path_and_root, load_doc_or_default, persist_doc}
 use crate::exact_limits::{self, ExactLimits};
 use crate::line_violations::line_violations;
 use crate::output::{
-    change_style, max_formatted_width, plural, print_error, write_change_row, write_ok_line,
-    ChangeKind, ChangeRow,
+    change_style, change_width, plural, print_error, write_change, write_ok_line, Change,
 };
 use crate::ExitStatus;
 
 struct RelaxReport {
-    changes: Vec<ChangeRow>,
+    changes: Vec<Change>,
 }
 
 pub fn run_relax<W1: WriteColor, W2: WriteColor>(
@@ -85,7 +84,7 @@ fn apply_relax_changes(
     violations: &HashMap<String, usize>,
     existing_rules: &ExactLimits,
     buffer: usize,
-) -> Vec<ChangeRow> {
+) -> Vec<Change> {
     let mut paths: Vec<_> = violations.iter().collect();
     paths.sort_by_key(|(path, _)| *path);
 
@@ -93,11 +92,10 @@ fn apply_relax_changes(
     for (path, &actual) in paths {
         let new_limit = actual.saturating_add(buffer);
         exact_limits::set_limit(doc, existing_rules, path, new_limit);
-        changes.push(ChangeRow {
+        changes.push(Change::Adjusted {
             path: path.clone(),
-            from: Some(actual),
-            to: Some(new_limit),
-            kind: ChangeKind::Adjusted,
+            from: actual,
+            to: new_limit,
         });
     }
 
@@ -109,23 +107,11 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &RelaxReport) -> std::io:
     let style = change_style();
 
     let mut changes: Vec<_> = report.changes.iter().collect();
-    changes.sort_by_key(|change| (change.to, change.from, change.path.as_str()));
-    let width = max_formatted_width(
-        changes
-            .iter()
-            .flat_map(|change| change.from.into_iter().chain(change.to)),
-    );
+    changes.sort_by_key(|change| (change.sort_value(), change.previous(), change.path()));
+    let width = change_width(&changes);
 
     for change in changes {
-        write_change_row(
-            writer,
-            &style,
-            width,
-            change.kind.symbol(),
-            change.from,
-            change.to,
-            &change.path,
-        )?;
+        write_change(writer, &style, width, change)?;
     }
     write_ok_line(
         writer,
@@ -169,11 +155,10 @@ max_lines = 10
     #[test]
     fn write_report_formats_output() {
         let report = RelaxReport {
-            changes: vec![ChangeRow {
+            changes: vec![Change::Adjusted {
                 path: "src/file.rs".into(),
-                from: Some(1_000),
-                to: Some(1_050),
-                kind: ChangeKind::Adjusted,
+                from: 1_000,
+                to: 1_050,
             }],
         };
 
@@ -194,17 +179,15 @@ max_lines = 10
     fn write_report_formats_plural_summary() {
         let report = RelaxReport {
             changes: vec![
-                ChangeRow {
+                Change::Adjusted {
                     path: "src/a.rs".into(),
-                    from: Some(10),
-                    to: Some(20),
-                    kind: ChangeKind::Adjusted,
+                    from: 10,
+                    to: 20,
                 },
-                ChangeRow {
+                Change::Adjusted {
                     path: "src/b.rs".into(),
-                    from: Some(30),
-                    to: Some(40),
-                    kind: ChangeKind::Adjusted,
+                    from: 30,
+                    to: 40,
                 },
             ],
         };

--- a/crates/loq_cli/src/tighten.rs
+++ b/crates/loq_cli/src/tighten.rs
@@ -11,13 +11,12 @@ use crate::config_edit::{config_path_and_root, line_threshold, load_doc_or_defau
 use crate::exact_limits::{self, ExactLimit, ExactLimits};
 use crate::line_violations::scan_line_violations;
 use crate::output::{
-    change_style, max_formatted_width, plural, print_error, write_change_row, write_ok_line,
-    ChangeKind, ChangeRow,
+    change_style, change_width, plural, print_error, write_change, write_ok_line, Change,
 };
 use crate::ExitStatus;
 
 struct TightenReport {
-    changes: Vec<ChangeRow>,
+    changes: Vec<Change>,
     removed: usize,
 }
 
@@ -70,11 +69,10 @@ fn apply_tighten_changes(
         if let Some(&actual) = violations.get(path) {
             if actual < limit.max_lines {
                 exact_limits::update_limit(doc, limit, actual);
-                changes.push(ChangeRow {
+                changes.push(Change::Adjusted {
                     path: path.to_string(),
-                    from: Some(limit.max_lines),
-                    to: Some(actual),
-                    kind: ChangeKind::Adjusted,
+                    from: limit.max_lines,
+                    to: actual,
                 });
             }
         } else {
@@ -93,24 +91,12 @@ fn write_report<W: WriteColor>(writer: &mut W, report: &TightenReport) -> std::i
 
     if !report.changes.is_empty() {
         let mut changes: Vec<_> = report.changes.iter().collect();
-        changes.sort_by_key(|change| (change.to, change.path.as_str()));
+        changes.sort_by_key(|change| (change.sort_value(), change.path()));
 
-        let width = max_formatted_width(
-            changes
-                .iter()
-                .flat_map(|change| change.from.into_iter().chain(change.to)),
-        );
+        let width = change_width(&changes);
 
         for change in changes {
-            write_change_row(
-                writer,
-                &style,
-                width,
-                change.kind.symbol(),
-                change.from,
-                change.to,
-                &change.path,
-            )?;
+            write_change(writer, &style, width, change)?;
         }
 
         let count = report.changes.len();
@@ -145,17 +131,15 @@ mod tests {
     fn write_report_sorts_by_limit_and_summarizes() {
         let report = TightenReport {
             changes: vec![
-                ChangeRow {
+                Change::Adjusted {
                     path: "b.rs".into(),
-                    from: Some(200),
-                    to: Some(150),
-                    kind: ChangeKind::Adjusted,
+                    from: 200,
+                    to: 150,
                 },
-                ChangeRow {
+                Change::Adjusted {
                     path: "a.rs".into(),
-                    from: Some(120),
-                    to: Some(110),
-                    kind: ChangeKind::Adjusted,
+                    from: 120,
+                    to: 110,
                 },
             ],
             removed: 1,


### PR DESCRIPTION
Replaces `ChangeRow`\u2019s independent kind, previous, and next fields with `Change` variants that only carry valid values. Baseline, tighten, and relax can no longer construct contradictory change states.

Change formatting now reads directly from the typed variants while preserving existing symbols, widths, ordering, and summaries.